### PR TITLE
banned users function improvement

### DIFF
--- a/misskaty/plugins/banned.py
+++ b/misskaty/plugins/banned.py
@@ -9,7 +9,7 @@ from utils import temp
 
 
 async def banned_users(_, client, message: Message):
-    return (message.from_user is not None or not message.sender_chat) and message.from_user.id in temp.BANNED_USERS
+    return message.from_user and message.from_user.id in temp.BANNED_USERS
 
 
 banned_user = filters.create(banned_users)


### PR DESCRIPTION
The `banned_users` function checks if `message.from_user` is not `None`, or if `message.sender_chat` is `False`, before checking if the user is in `temp.BANNED_USERS`. However, if `message.from_user` is `None` and `message.sender_chat` is also `None`, the function will return `False`, which means that the message will not be filtered correctly.