### PR TITLE
Prefer fastfetch with neofetch fallback and rename stats label to KuriGram

### DIFF
--- a/misskaty/plugins/dev.py
+++ b/misskaty/plugins/dev.py
@@ -285,9 +285,16 @@ async def server_stats(_, ctx: Message) -> "Message":
     disk_used = get_readable_file_size(used)
     disk_free = get_readable_file_size(free)
 
-    neofetch = (await shell_exec("neofetch --stdout"))[0]
+    fastfetch_cmd = (
+        "if command -v fastfetch >/dev/null 2>&1; then "
+        "fastfetch --logo none --pipe false --color never; "
+        "elif command -v neofetch >/dev/null 2>&1; then "
+        "neofetch --stdout; "
+        "else echo 'System fetch tool is not available.'; fi"
+    )
+    system_fetch = (await shell_exec(fastfetch_cmd))[0]
 
-    caption = f"<b>{BOT_NAME} {misskaty_version} is Up and Running successfully.</b>\n\n<code>{neofetch}</code>\n\n**OS Uptime:** <code>{osuptime}</code>\n<b>Bot Uptime:</b> <code>{currentTime}</code>\n**Bot Usage:** <code>{botusage}</code>\n\n**Total Space:** <code>{disk_total}</code>\n**Free Space:** <code>{disk_free}</code>\n\n**Download:** <code>{download}</code>\n**Upload:** <code>{upload}</code>\n\n<b>PyroFork Version</b>: <code>{pyrover}</code>\n<b>Python Version</b>: <code>{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]} {sys.version_info[3].title()}</code>"
+    caption = f"<b>{BOT_NAME} {misskaty_version} is Up and Running successfully.</b>\n\n<code>{system_fetch}</code>\n\n**OS Uptime:** <code>{osuptime}</code>\n<b>Bot Uptime:</b> <code>{currentTime}</code>\n**Bot Usage:** <code>{botusage}</code>\n\n**Total Space:** <code>{disk_total}</code>\n**Free Space:** <code>{disk_free}</code>\n\n**Download:** <code>{download}</code>\n**Upload:** <code>{upload}</code>\n\n<b>KuriGram Version</b>: <code>{pyrover}</code>\n<b>Python Version</b>: <code>{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]} {sys.version_info[3].title()}</code>"
 
     if "oracle" in platform.uname().release:
         return await ctx.reply(caption)
@@ -700,4 +707,3 @@ if AUTO_RESTART:
     scheduler = AsyncIOScheduler(timezone="Asia/Jakarta")
     scheduler.add_job(auto_restart, trigger="interval", days=3)
     scheduler.start()
-


### PR DESCRIPTION
### Motivation
- Ensure the server `stats` output prefers the newer `fastfetch` tool when present and remains compatible on systems with only `neofetch` or neither tool installed.
- Update the UI branding shown in the stats caption from `PyroFork` to `KuriGram`.

### Description
- In `misskaty/plugins/dev.py` updated `server_stats` to build a `fastfetch_cmd` shell conditional that runs `fastfetch` when available, falls back to `neofetch`, and otherwise prints a safe message, and set `system_fetch = (await shell_exec(fastfetch_cmd))[0]`.
- Replaced the previous direct `neofetch` usage with `system_fetch` in the stats caption.
- Renamed the caption label from `<b>PyroFork Version</b>` to `<b>KuriGram Version</b>` while leaving the reported runtime version variable (`pyrover`) unchanged.
- No other logic or behavioral changes were introduced.

### Testing
- Ran `python -m compileall misskaty/plugins/dev.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698d98490b3c832c8ba9fbece267da11)

## Summary by Sourcery

Update server stats output to prefer fastfetch with a neofetch fallback and refresh the displayed branding.

New Features:
- Add conditional support for using fastfetch in server stats with a fallback to neofetch or a safe message when neither is available.

Enhancements:
- Update the server stats caption to use the new KuriGram branding while retaining existing version information semantics.