### PR TITLE
Normalize ChatPermissions across plugins and make nightmode MongoDB-safe

### DIFF
--- a/misskaty/helper/chat_permissions.py
+++ b/misskaty/helper/chat_permissions.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import inspect
+from functools import lru_cache
+from typing import Any
+
+from pyrogram.types import ChatPermissions
+
+
+PERMISSION_ALIASES = {
+    "can_send_docs": "can_send_documents",
+    "can_send_voices": "can_send_voice_notes",
+    "can_send_roundvideos": "can_send_video_notes",
+    "can_send_plain": "can_send_messages",
+    "can_send_gifs": "can_send_other_messages",
+    "can_send_games": "can_send_other_messages",
+    "can_send_inline": "can_send_other_messages",
+    "can_send_stickers": "can_send_other_messages",
+}
+
+
+@lru_cache(maxsize=1)
+def available_permission_fields() -> set[str]:
+    signature = inspect.signature(ChatPermissions.__init__)
+    return {
+        name
+        for name in signature.parameters
+        if name not in {"self", "kwargs", "all_perms"}
+    }
+
+
+def _read_perm_value(perm_obj: Any, key: str) -> Any:
+    if isinstance(perm_obj, dict):
+        if key in perm_obj:
+            return perm_obj[key]
+        alias = PERMISSION_ALIASES.get(key)
+        if alias and alias in perm_obj:
+            return perm_obj[alias]
+        for legacy, current in PERMISSION_ALIASES.items():
+            if current == key and legacy in perm_obj:
+                return perm_obj[legacy]
+        return None
+
+    if hasattr(perm_obj, key):
+        return getattr(perm_obj, key)
+
+    alias = PERMISSION_ALIASES.get(key)
+    if alias and hasattr(perm_obj, alias):
+        return getattr(perm_obj, alias)
+
+    for legacy, current in PERMISSION_ALIASES.items():
+        if current == key and hasattr(perm_obj, legacy):
+            return getattr(perm_obj, legacy)
+
+    return None
+
+
+def export_permissions(perm_obj: Any) -> dict[str, bool]:
+    data: dict[str, bool] = {}
+    for field in available_permission_fields():
+        value = _read_perm_value(perm_obj, field)
+        if value is None:
+            continue
+        data[field] = bool(value)
+    return data
+
+
+def build_chat_permissions(perm_obj: Any = None, **overrides: bool) -> ChatPermissions:
+    data = export_permissions(perm_obj) if perm_obj is not None else {}
+    data.update({k: v for k, v in overrides.items() if k in available_permission_fields()})
+    return ChatPermissions(**data)
+
+
+def empty_chat_permissions() -> ChatPermissions:
+    return build_chat_permissions(
+        **{field: False for field in available_permission_fields()},
+    )
+
+
+def full_chat_permissions() -> ChatPermissions:
+    return build_chat_permissions(
+        **{field: True for field in available_permission_fields()},
+    )
+

--- a/misskaty/plugins/admin.py
+++ b/misskaty/plugins/admin.py
@@ -36,7 +36,7 @@ from pyrogram.errors import (
     PeerIdInvalid,
     UsernameNotOccupied,
 )
-from pyrogram.types import ChatMember, ChatPermissions, ChatPrivileges, Message
+from pyrogram.types import ChatMember, ChatPrivileges, Message
 
 from database.warn_db import add_warn, get_warn, remove_warns
 from misskaty import app
@@ -54,6 +54,7 @@ from misskaty.helper.functions import (
     time_converter,
 )
 from misskaty.helper.localization import use_chat_lang
+from misskaty.helper.chat_permissions import empty_chat_permissions
 from misskaty.vars import COMMAND_HANDLER, SUDO, OWNER_ID
 
 LOGGER = getLogger("MissKaty")
@@ -558,7 +559,7 @@ async def mute(client, message, strings):
             if len(time_value[:-1]) < 3:
                 await message.chat.restrict_member(
                     user_id,
-                    permissions=ChatPermissions(all_perms=False),
+                    permissions=empty_chat_permissions(),
                     until_date=temp_mute,
                 )
                 await message.reply_text(msg, reply_markup=keyboard)
@@ -571,7 +572,7 @@ async def mute(client, message, strings):
         msg += strings("banned_reason").format(reas=reason)
     try:
         await message.chat.restrict_member(
-            user_id, permissions=ChatPermissions(all_perms=False)
+            user_id, permissions=empty_chat_permissions()
         )
         await message.reply_text(msg, reply_markup=keyboard)
     except Exception as e:

--- a/misskaty/plugins/blacklist_chat.py
+++ b/misskaty/plugins/blacklist_chat.py
@@ -27,7 +27,6 @@ from datetime import datetime, timedelta
 
 from pyrogram import filters
 from pyrogram.errors import ChatAdminRequired
-from pyrogram.types import ChatPermissions
 
 from database.blacklist_db import (
     delete_blacklist_filter,
@@ -37,6 +36,7 @@ from database.blacklist_db import (
 from misskaty import app
 from misskaty.core.decorator.errors import capture_err
 from misskaty.core.decorator.permissions import adminsOnly, list_admins
+from misskaty.helper.chat_permissions import empty_chat_permissions
 from misskaty.vars import SUDO, OWNER_ID
 
 __MODULE__ = "Blacklist"
@@ -110,7 +110,7 @@ async def blacklist_filters_re(self, message):
                 await message.delete_msg()
                 await message.chat.restrict_member(
                     user.id,
-                    ChatPermissions(all_perms=False),
+                    empty_chat_permissions(),
                     until_date=datetime.now() + timedelta(hours=1),
                 )
             except ChatAdminRequired:


### PR DESCRIPTION
### Motivation
- Pyrogram/Telegram permission fields changed (e.g. `can_send_docs` → `can_send_documents`) and persisted nightmode jobs in MongoDB could contain old-shaped permission payloads, causing runtime conflicts after upgrades.
- Make permission handling resilient to mixed/legacy schemas and ensure scheduled nightmode jobs can be restored safely from MongoDB regardless of schema changes.

### Description
- Added new helper `misskaty/helper/chat_permissions.py` which detects the installed `ChatPermissions` signature, maps legacy field names to current names, and exposes `export_permissions`, `build_chat_permissions`, `empty_chat_permissions`, and `full_chat_permissions` helpers for safe conversion and construction of permission objects.
- Updated `misskaty/plugins/nightmodev2.py` to store a plain permission dictionary when scheduling jobs (MongoDB-safe) and to rebuild a valid `ChatPermissions` at runtime via `build_chat_permissions` when restoring jobs, and to use `empty_chat_permissions`/`full_chat_permissions` instead of `all_perms` constructor use.
- Updated `misskaty/plugins/locks.py` to use the new helper for reading and building permissions, remapped old lock keys to current permission fields, and replaced direct `ChatPermissions` constructor usage with `build_chat_permissions`/`empty_chat_permissions`/`full_chat_permissions`.
- Replaced legacy `ChatPermissions(all_perms=False)` usages in `misskaty/plugins/admin.py` and `misskaty/plugins/blacklist_chat.py` with `empty_chat_permissions()` to keep restriction behavior consistent after schema updates.

### Testing
- Ran `python -m compileall` on the modified modules (`misskaty/helper/chat_permissions.py`, `misskaty/plugins/nightmodev2.py`, `misskaty/plugins/locks.py`, `misskaty/plugins/admin.py`, `misskaty/plugins/blacklist_chat.py`) and compilation completed successfully.
- Verified repository status and changes via `git status --short` and committed the patch; commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698da3e5bfb0832c943696a12936b932)

## Summary by Sourcery

Normalize chat permission handling across plugins and make persisted nightmode permissions schema-agnostic.

New Features:
- Introduce a chat permissions helper module to export, normalize, and reconstruct ChatPermissions objects from mixed or legacy schemas.

Enhancements:
- Align lock and permission mappings with the current Pyrogram/Telegram ChatPermissions fields, including consolidating several legacy permissions into modern equivalents.
- Update nightmode scheduling to persist permissions as plain dictionaries and rebuild valid ChatPermissions at runtime for MongoDB-stored jobs.
- Replace direct ChatPermissions(all_perms=...) usages across admin, blacklist, and locks plugins with helper-based constructors to ensure forward-compatible restriction behavior.