### PR TITLE
Fix fastfetch 'disable' option, update session credit, and improve wait_for_click handling

### DIFF
--- a/misskaty/core/listener.py
+++ b/misskaty/core/listener.py
@@ -183,7 +183,11 @@ async def wait_for_click(
     future = asyncio.get_running_loop().create_future()
 
     async def _on_callback(_, query):
-        if query.message.chat.id != self.chat.id or query.message.id != self.id:
+        query_message = query.message
+        if not query_message:
+            return
+
+        if query_message.chat.id != self.chat.id or query_message.id != self.id:
             return
 
         if (
@@ -194,6 +198,9 @@ async def wait_for_click(
             with suppress(Exception):
                 await query.answer(_UNALLOWED_CLICK_TEXT, show_alert=True)
             return
+
+        with suppress(Exception):
+            await query.answer()
 
         if not future.done():
             future.set_result(query)

--- a/misskaty/plugins/dev.py
+++ b/misskaty/plugins/dev.py
@@ -287,7 +287,7 @@ async def server_stats(_, ctx: Message) -> "Message":
 
     fastfetch_cmd = (
         "if command -v fastfetch >/dev/null 2>&1; then "
-        "fastfetch --logo none --pipe true --disable localip --disable publicip; "
+        "fastfetch --logo none --pipe true | sed '/Local IP/d;/Public IP/d'; "
         "elif command -v neofetch >/dev/null 2>&1; then "
         "neofetch --stdout | sed '/Local IP/d;/Public IP/d'; "
         "else echo 'System fetch tool is not available.'; fi"

--- a/misskaty/plugins/session_generator.py
+++ b/misskaty/plugins/session_generator.py
@@ -306,5 +306,5 @@ async def generate_session(
     await client.disconnect()
     await bot.send_message(
         msg.chat.id,
-        f'» Successfully generated your {"Telethon" if telethon else "Pyrogram"} String Session.\n\nPlease check saved messages to get it ! \n\n**A String Generator bot by ** @IAmCuteCodes',
+        f'» Successfully generated your {"Telethon" if telethon else "Pyrogram"} String Session.\n\nPlease check saved messages to get it ! \n\n**A String Generator bot by ** @Yasir_ID',
     )


### PR DESCRIPTION
### Motivation
- The `/stats` command used `fastfetch` with unsupported `--disable` flags which caused `unknown option: disable` errors on some systems.
- Session generator credit referenced the wrong Telegram handle and needed updating.
- `wait_for_click` sometimes left the caller waiting until timeout even after a button was clicked due to unhandled callback shapes and not acknowledging valid callbacks immediately.

### Description
- Replaced the `fastfetch` invocation to pipe its output through `sed` to remove Local/Public IP lines instead of using unsupported `--disable` flags, avoiding the `unknown option: disable` error (`misskaty/plugins/dev.py`).
- Replaced the session generator attribution `@IAmCuteCodes` with `@Yasir_ID` in the success message (`misskaty/plugins/session_generator.py`).
- Hardened `wait_for_click` by checking that `query.message` exists before accessing its attributes and calling `query.answer()` (within a `suppress(Exception)`) for valid clicks prior to resolving the waiting future, ensuring clicks are acknowledged and the future resolves immediately (`misskaty/core/listener.py`).

### Testing
- Compiled modified files with `python -m compileall misskaty/core/listener.py misskaty/plugins/session_generator.py misskaty/plugins/dev.py` which completed successfully.
- Verified repository status with `git status --short` to ensure changes were committed; working tree is clean after the commit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698daec50598832cb53130ff901da2df)

## Summary by Sourcery

Update system stats fetching, attribution text, and click handling for interactive messages.

Bug Fixes:
- Avoid fastfetch failures by removing unsupported local/public IP disable flags and filtering those lines via sed instead.
- Ensure wait_for_click correctly ignores callbacks without messages and immediately acknowledges valid clicks to prevent unnecessary timeouts.

Enhancements:
- Update session generator success message to credit the new Telegram handle in the attribution text.