### PR TITLE
Fix broadcast crash; make broadcast delivery robust; add yt thumbnail fallback; API param fixes

### DIFF
--- a/misskaty/plugins/broadcast.py
+++ b/misskaty/plugins/broadcast.py
@@ -24,7 +24,15 @@ async def broadcast(_, ctx: Message):
 
     success = 0
     async for user in await db.get_all_users():
-        pti, sh = await broadcast_messages(int(user["id"]), b_msg)
+        user_id = user.get("id", user.get("_id"))
+        try:
+            user_id = int(user_id)
+        except (TypeError, ValueError):
+            failed += 1
+            done += 1
+            continue
+
+        pti, sh = await broadcast_messages(user_id, b_msg)
         if pti:
             success += 1
         elif pti is False:
@@ -38,9 +46,9 @@ async def broadcast(_, ctx: Message):
         await asyncio.sleep(2)
         if not done % 20:
             await sts.edit(
-                f"Broadcast in progress:\n\nTotal Users {total_users}\nCompleted: {done} / {total_users}\nSuccess: {success}\nBlocked: {blocked}\nDeleted: {deleted}"
+                f"Broadcast in progress:\n\nTotal Users {total_users}\nCompleted: {done} / {total_users}\nSuccess: {success}\nBlocked: {blocked}\nDeleted: {deleted}\nFailed: {failed}"
             )
     time_taken = datetime.timedelta(seconds=int(time.time() - start_time))
     await sts.edit(
-        f"Broadcast Completed:\nCompleted in {time_taken} seconds.\n\nTotal Users {total_users}\nCompleted: {done} / {total_users}\nSuccess: {success}\nBlocked: {blocked}\nDeleted: {deleted}"
+        f"Broadcast Completed:\nCompleted in {time_taken} seconds.\n\nTotal Users {total_users}\nCompleted: {done} / {total_users}\nSuccess: {success}\nBlocked: {blocked}\nDeleted: {deleted}\nFailed: {failed}"
     )

--- a/misskaty/plugins/dev.py
+++ b/misskaty/plugins/dev.py
@@ -100,7 +100,7 @@ async def edit_or_reply(self, msg, **kwargs):
 @app.on_message(filters.command(["privacy"], COMMAND_HANDLER))
 @use_chat_lang()
 async def privacy_policy(self: Client, ctx: Message, strings):
-    await ctx.reply(strings("privacy_policy").format(botname=self.me.first_name), message_effect_id=5104841245755180586 if ctx.chat.type.value == "private" else None)
+    await ctx.reply(strings("privacy_policy").format(botname=self.me.first_name), effect_id=5104841245755180586 if ctx.chat.type.value == "private" else None)
 
 
 @app.on_message(filters.command(["stars"], COMMAND_HANDLER))
@@ -235,7 +235,7 @@ async def donate(self: Client, ctx: Message):
             "https://img.yasirweb.eu.org/file/ee74ce527fb8264b54691.jpg",
             caption="Hi, If you find this bot useful, you can make a donation to the account below. Because this bot server uses VPS and is not free. Thank You..\n\n<b>Indonesian Payment:</b>\n<b>QRIS:</b> https://img.yasirweb.eu.org/file/ee74ce527fb8264b54691.jpg (Yasir Store)\n<b>Bank Jago:</b> 109641845083 (Yasir Aris M)\n\nFor international people can use PayPal to support me or via GitHub Sponsor:\nhttps://paypal.me/yasirarism\nhttps://github.com/sponsors/yasirarism\n\n<b>Source:</b> @BeriKopi",
             reply_parameters=pyro_types.ReplyParameters(message_id=ctx.id),
-            message_effect_id=5159385139981059251
+            effect_id=5159385139981059251
             if ctx.chat.type.value == "private"
             else None,
         )

--- a/misskaty/plugins/federation.py
+++ b/misskaty/plugins/federation.py
@@ -582,7 +582,7 @@ async def fban_user(client, message):
         )
     fed_id = await get_fed_id(chat.id)
     if not fed_id:
-        return await message.reply_text("**This chat is not a part of any federation.")
+        return await message.reply_text("**This chat is not a part of any federation.**")
     info = await get_fed_info(fed_id)
     fed_admins = info["fadmins"]
     fed_owner = info["owner_id"]
@@ -681,7 +681,7 @@ async def funban_user(client, message):
         return
     fed_id = await get_fed_id(chat.id)
     if not fed_id:
-        return await message.reply_text("**This chat is not a part of any federation.")
+        return await message.reply_text("**This chat is not a part of any federation.**")
     info = await get_fed_info(fed_id)
     fed_admins = info["fadmins"]
     fed_owner = info["owner_id"]
@@ -811,12 +811,12 @@ async def fbroadcast_message(client, message):
         return
     fed_id = await get_fed_id(chat.id)
     if not fed_id:
-        return await message.reply_text("**This chat is not a part of any federation.")
+        return await message.reply_text("**This chat is not a part of any federation.**")
     info = await get_fed_info(fed_id)
     fed_owner = info["owner_id"]
     fed_admins = info["fadmins"]
     all_admins = [fed_owner] + fed_admins + [int(BOT_ID)]
-    if from_user.id not in all_admins and from_user.id not in SUDO and from_user != OWNER_ID:
+    if from_user.id not in all_admins and from_user.id not in SUDO and from_user.id != OWNER_ID:
         return await message.reply_text(
             "You need to be a Fed Admin to use this command"
         )

--- a/misskaty/plugins/start_help.py
+++ b/misskaty/plugins/start_help.py
@@ -112,14 +112,14 @@ async def start(self, ctx: Message, strings):
             await ctx.reply(
                 text,
                 link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
-                message_effect_id=5104841245755180586,
+                effect_id=5104841245755180586,
             )
             if module == "federation":
                 return await ctx.reply(
                     text=text,
                     reply_markup=FED_MARKUP,
                     link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
-                    message_effect_id=5104841245755180586,
+                    effect_id=5104841245755180586,
                 )
             await ctx.reply(
                 text,
@@ -127,12 +127,12 @@ async def start(self, ctx: Message, strings):
                     [[InlineKeyboardButton("back", callback_data="help_back")]]
                 ),
                 link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
-                message_effect_id=5104841245755180586,
+                effect_id=5104841245755180586,
             )
         elif name == "help":
             text, keyb = await help_parser(ctx.from_user.first_name, strings)
             await ctx.reply(
-                text, reply_markup=keyb, message_effect_id=5104841245755180586
+                text, reply_markup=keyb, effect_id=5104841245755180586
             )
     else:
         await self.send_photo(
@@ -152,7 +152,7 @@ async def commands_callbacc(_, cb: CallbackQuery, strings):
         cb.message.chat.id,
         text=text,
         reply_markup=keyb,
-        message_effect_id=5104841245755180586,
+        effect_id=5104841245755180586,
     )
     await cb.message.delete_msg()
 
@@ -199,7 +199,7 @@ async def help_command(_, ctx: Message, strings):
             await ctx.reply(
                 text,
                 link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
-                message_effect_id=5104841245755180586,
+                effect_id=5104841245755180586,
             )
         else:
             text, help_keyboard = await help_parser(ctx.from_user.first_name, strings)
@@ -207,7 +207,7 @@ async def help_command(_, ctx: Message, strings):
                 text,
                 reply_markup=help_keyboard,
                 link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
-                message_effect_id=5104841245755180586,
+                effect_id=5104841245755180586,
             )
     else:
         text, help_keyboard = await help_parser(ctx.from_user.first_name, strings)
@@ -215,7 +215,7 @@ async def help_command(_, ctx: Message, strings):
             text,
             reply_markup=help_keyboard,
             link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
-            message_effect_id=5104841245755180586,
+            effect_id=5104841245755180586,
         )
 
 

--- a/utils.py
+++ b/utils.py
@@ -68,25 +68,27 @@ def demoji(teks):
 
 
 async def broadcast_messages(user_id, message):
-    try:
-        await message.forward(chat_id=user_id)
-        return True, "Succes"
-    except FloodWait as e:
-        await asyncio.sleep(e.value)
-        return await broadcast_messages(user_id, message)
-    except InputUserDeactivated:
-        await db.delete_user(int(user_id))
-        LOGGER.info(f"{user_id} - Removed from Database, since deleted account.")
-        return False, "Deleted"
-    except UserIsBlocked:
-        LOGGER.info(f"{user_id} - Blocked the bot.")
-        return False, "Blocked"
-    except PeerIdInvalid:
-        await db.delete_user(int(user_id))
-        LOGGER.info(f"{user_id} - PeerIdInvalid")
-        return False, "Error"
-    except Exception:
-        return False, "Error"
+    while True:
+        try:
+            await message.copy(chat_id=user_id)
+            return True, "Success"
+        except FloodWait as e:
+            await asyncio.sleep(e.value)
+            continue
+        except InputUserDeactivated:
+            await db.delete_user(int(user_id))
+            LOGGER.info(f"{user_id} - Removed from Database, since deleted account.")
+            return False, "Deleted"
+        except UserIsBlocked:
+            LOGGER.info(f"{user_id} - Blocked the bot.")
+            return False, "Blocked"
+        except PeerIdInvalid:
+            await db.delete_user(int(user_id))
+            LOGGER.info(f"{user_id} - PeerIdInvalid")
+            return False, "Error"
+        except Exception:
+            return False, "Error"
+
 
 
 def get_size(size):


### PR DESCRIPTION
### Motivation
- Prevent the `/broadcast` handler from crashing when user records lack an `id` field by accepting alternate shapes and skipping invalid entries. 
- Improve reliability of direct message delivery by replacing fragile `forward` usage with a `copy`-based approach and handling `FloodWait` with retries. 
- Ensure video uploads always have a thumbnail by generating one locally when remote thumbnails fail. 
- Align message parameter names with the current API and fix minor federation/formatting issues.

### Description
- Safely resolve user identifiers in the broadcast loop by reading `user.get("id", user.get("_id"))`, validating `int()` conversion, and skipping malformed records while accounting them in the `Failed` counter (`misskaty/plugins/broadcast.py`).
- Replace `message.forward()` with `message.copy()` and implement a `FloodWait` retry loop in `broadcast_messages()` to avoid transient delivery failures, and correct the success return string (`utils.py`).
- Add `generate_thumb_with_ffmpeg()` to create a fallback thumbnail from the downloaded video when the remote thumbnail cannot be retrieved, and wire this fallback into the YT download flow (`misskaty/plugins/ytdl_plugins.py`).
- Replace deprecated `message_effect_id` usage with `effect_id` in several UI flows and fix small federation permission logic and a missing Markdown closing bold in replies (`misskaty/plugins/start_help.py`, `misskaty/plugins/dev.py`, `misskaty/plugins/federation.py`).

### Testing
- Run syntax/smoke checks with `python -m compileall misskaty/plugins/ytdl_plugins.py misskaty/plugins/federation.py misskaty/plugins/start_help.py misskaty/plugins/dev.py utils.py`, which completed successfully (earlier validation during the prior changes).
- Run `python -m compileall misskaty/plugins/broadcast.py` after the broadcast fix, which completed successfully.
- No automated runtime/integration tests were added; all changes were validated with the above compile checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ebb4c5498832cbdf5568b14704137)

## Summary by Sourcery

Improve broadcast robustness, media thumbnail handling, and API parameter usage across messaging plugins.

Bug Fixes:
- Prevent broadcasts from crashing on malformed or legacy user records and track failed user entries in progress and completion summaries.
- Handle Telegram broadcast rate limiting more reliably and correct the success status message.
- Fix federation messages with missing markdown closing and correct federation broadcast owner permission checks.
- Update message reply calls to use the correct effect_id parameter instead of deprecated message_effect_id.

Enhancements:
- Switch broadcast delivery from forwarding to copying messages to improve reliability and behavior consistency.
- Add a local ffmpeg-based thumbnail generator as a fallback when remote thumbnails cannot be downloaded for video uploads.

Tests:
- Run Python compile-time checks on updated modules to validate syntax after changes.