### PR TITLE
Replace IMDb HTML scraping with GraphQL API and refactor parsing

### DIFF
--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -4,6 +4,7 @@
 # * Copyright ©YasirPedia All rights reserved
 import contextlib
 import html
+import inspect
 import logging
 import re
 import sys
@@ -224,6 +225,13 @@ def _with_html_placeholders(payload: dict) -> dict:
         if isinstance(value, str):
             enriched[f"{key}_html"] = html.escape(value)
     return enriched
+
+
+def _preview_kwargs(is_disabled: bool) -> dict:
+    params = inspect.signature(Client.edit_message_text).parameters
+    if "link_preview_options" in params:
+        return {"link_preview_options": {"is_disabled": is_disabled}}
+    return {"disable_web_page_preview": is_disabled}
 
 
 def render_imdb_template_with_buttons(template: str, payload: dict):
@@ -1268,7 +1276,7 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                     res_str,
                     parse_mode=enums.ParseMode.HTML,
                     reply_markup=markup,
-                    disable_web_page_preview=disable_web_preview,
+                    **_preview_kwargs(disable_web_preview),
                 )
             elif thumb := r_json.get("image"):
                 try:
@@ -1300,7 +1308,7 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                         res_str,
                         parse_mode=enums.ParseMode.HTML,
                         reply_markup=markup,
-                        disable_web_page_preview=disable_web_preview,
+                        **_preview_kwargs(disable_web_preview),
                     )
                 except Exception as err:
                     LOGGER.error(
@@ -1311,14 +1319,14 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                             res_str,
                             parse_mode=enums.ParseMode.HTML,
                             reply_markup=markup,
-                            disable_web_page_preview=disable_web_preview,
+                            **_preview_kwargs(disable_web_preview),
                         )
             else:
                 await query.message.edit_msg(
                     res_str,
                     parse_mode=enums.ParseMode.HTML,
                     reply_markup=markup,
-                    disable_web_page_preview=disable_web_preview,
+                    **_preview_kwargs(disable_web_preview),
                 )
         except httpx.HTTPError as exc:
             await query.message.edit_msg(
@@ -1663,7 +1671,7 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                     res_str,
                     parse_mode=enums.ParseMode.HTML,
                     reply_markup=markup,
-                    disable_web_page_preview=disable_web_preview,
+                    **_preview_kwargs(disable_web_preview),
                 )
             elif thumb := r_json.get("image"):
                 try:
@@ -1695,7 +1703,7 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                         res_str,
                         parse_mode=enums.ParseMode.HTML,
                         reply_markup=markup,
-                        disable_web_page_preview=disable_web_preview,
+                        **_preview_kwargs(disable_web_preview),
                     )
                 except Exception as err:
                     LOGGER.error(f"Error while displaying IMDB Data. ERROR: {err}")
@@ -1704,14 +1712,14 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                             res_str,
                             parse_mode=enums.ParseMode.HTML,
                             reply_markup=markup,
-                            disable_web_page_preview=disable_web_preview,
+                            **_preview_kwargs(disable_web_preview),
                         )
             else:
                 await query.message.edit_msg(
                     res_str,
                     parse_mode=enums.ParseMode.HTML,
                     reply_markup=markup,
-                    disable_web_page_preview=disable_web_preview,
+                    **_preview_kwargs(disable_web_preview),
                 )
         except httpx.HTTPError as exc:
             await query.message.edit_msg(

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -4,7 +4,6 @@
 # * Copyright ©YasirPedia All rights reserved
 import contextlib
 import html
-import json
 import logging
 import re
 import sys
@@ -12,7 +11,6 @@ from typing import Optional
 from urllib.parse import quote_plus
 
 import httpx
-from bs4 import BeautifulSoup
 from pykeyboard import InlineButton, InlineKeyboard
 from pyrogram import Client, enums
 from pyrogram.errors import (
@@ -56,6 +54,128 @@ from utils import demoji
 
 LOGGER = logging.getLogger("MissKaty")
 LIST_CARI = Cache(filename="imdb_cache.db", path="cache", in_memory=False)
+IMDB_GRAPHQL_URL = "https://caching.graphql.imdb.com/"
+IMDB_GRAPHQL_HEADERS = {
+    "accept": "application/graphql+json, application/json",
+    "accept-language": "en-US,en;q=0.9",
+    "content-type": "application/json",
+    "origin": "https://www.imdb.com",
+    "user-agent": (
+        "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Mobile Safari/537.36"
+    ),
+}
+IMDB_TITLE_QUERY = """
+query GetTitle($id: ID!) {
+  title(id: $id) {
+    id
+    titleText { text }
+    originalTitleText { text }
+    titleType { text }
+    releaseYear { year }
+    runtime { seconds }
+    ratingsSummary { aggregateRating voteCount }
+    certificate { rating }
+    genres { genres { text } }
+    countriesOfOrigin { countries { text } }
+    spokenLanguages { spokenLanguages { text } }
+    plot { plotText { plainText } }
+    keywords { edges { node { text } } }
+    nominations { total }
+    latestTrailer { playbackURLs { url } }
+    primaryImage { url }
+    principalCredits {
+      category { text }
+      credits {
+        name { id nameText { text } }
+      }
+    }
+  }
+}
+"""
+
+
+def _format_runtime(seconds: Optional[int]) -> str:
+    if not seconds:
+        return "-"
+    total_minutes = seconds // 60
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{hours}h {minutes}m" if hours else f"{minutes}m"
+
+
+async def _fetch_imdb_title_details(movie_id: str) -> dict:
+    payload = {
+        "query": IMDB_TITLE_QUERY,
+        "operationName": "GetTitle",
+        "variables": {"id": f"tt{movie_id}"},
+    }
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            IMDB_GRAPHQL_URL,
+            headers=IMDB_GRAPHQL_HEADERS,
+            json=payload,
+        )
+        response.raise_for_status()
+    title = response.json().get("data", {}).get("title")
+    if not title:
+        raise AttributeError("IMDb title data not found")
+    return title
+
+
+def _graphql_to_legacy_json(title: dict) -> dict:
+    name = (title.get("titleText") or {}).get("text")
+    trailer_url = None
+    playback_urls = (title.get("latestTrailer") or {}).get("playbackURLs") or []
+    if playback_urls:
+        trailer_url = playback_urls[0].get("url")
+    directors, writers, actors = [], [], []
+    for group in title.get("principalCredits") or []:
+        cat = (group.get("category") or {}).get("text", "")
+        names = []
+        for item in group.get("credits") or []:
+            n = ((item.get("name") or {}).get("nameText") or {}).get("text")
+            nid = (item.get("name") or {}).get("id")
+            if n:
+                names.append(
+                    {
+                        "name": n,
+                        "url": f"https://www.imdb.com/name/{nid}/" if nid else "",
+                    }
+                )
+        if cat == "Director":
+            directors = names
+        elif cat in ["Writer", "Writers", "Creator"]:
+            writers = names
+        elif cat in ["Stars", "Cast"]:
+            actors = names
+    return {
+        "name": name,
+        "alternateName": (title.get("originalTitleText") or {}).get("text"),
+        "@type": (title.get("titleType") or {}).get("text") or "",
+        "contentRating": (title.get("certificate") or {}).get("rating"),
+        "aggregateRating": {
+            "ratingValue": (title.get("ratingsSummary") or {}).get("aggregateRating"),
+            "ratingCount": (title.get("ratingsSummary") or {}).get("voteCount"),
+        },
+        "genre": [
+            g.get("text")
+            for g in (title.get("genres") or {}).get("genres", [])
+            if g and g.get("text")
+        ],
+        "description": (((title.get("plot") or {}).get("plotText") or {}).get("plainText")),
+        "keywords": ", ".join(
+            [
+                (edge.get("node") or {}).get("text")
+                for edge in (title.get("keywords") or {}).get("edges", [])
+                if edge and (edge.get("node") or {}).get("text")
+            ]
+        ),
+        "image": (title.get("primaryImage") or {}).get("url"),
+        "trailer": {"url": trailer_url} if trailer_url else {},
+        "director": directors,
+        "creator": [{"@type": "Person", **w} for w in writers],
+        "actor": actors,
+    }
 
 
 class _ImdbTemplateDefaults(dict):
@@ -830,12 +950,8 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
         try:
             await query.message.edit_msg("⏳ Permintaan kamu sedang diproses.. ")
             imdb_url = f"https://m.imdb.com/title/tt{movie}/"
-            resp = await fetch.get(imdb_url)
-            resp.raise_for_status()
-            sop = BeautifulSoup(resp, "lxml")
-            r_json = json.loads(
-                sop.find("script", attrs={"type": "application/ld+json"}).contents[0]
-            )
+            title_data = await _fetch_imdb_title_details(movie)
+            r_json = _graphql_to_legacy_json(title_data)
             ott = await search_jw(
                 r_json.get("alternateName") or r_json.get("name"), "ID"
             )
@@ -861,22 +977,14 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
             rilis = "-"
             rilis_url = ""
             summary = ""
-            tahun = (
-                re.findall(r"\d{4}\W\d{4}|\d{4}-?", sop.title.text)[0]
-                if re.findall(r"\d{4}\W\d{4}|\d{4}-?", sop.title.text)
-                else "N/A"
-            )
+            tahun = str((title_data.get("releaseYear") or {}).get("year") or "N/A")
             res_str += f"<b>📹 Judul:</b> <a href=\"{imdb_url}\">{r_json.get('name')} [{tahun}]</a> (<code>{typee}</code>)\n"
             if aka := r_json.get("alternateName"):
                 res_str += f"<b>📢 AKA:</b> <code>{aka}</code>\n\n"
             else:
                 res_str += "\n"
-            if durasi := sop.select('li[data-testid="title-techspec_runtime"]'):
-                durasi = (
-                    durasi[0]
-                    .find(class_="ipc-metadata-list-item__content-container")
-                    .text
-                )
+            if runtime_seconds := (title_data.get("runtime") or {}).get("seconds"):
+                durasi = _format_runtime(runtime_seconds)
                 duration_raw = durasi
                 duration_text = (await gtranslate(durasi, "auto", "id")).text
                 res_str += f"<b>Durasi:</b> <code>{duration_text}</code>\n"
@@ -889,17 +997,9 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                 rating_value = rating.get("ratingValue", "-")
                 rating_count = rating.get("ratingCount", "-")
                 res_str += f"<b>Peringkat:</b> <code>{rating_value}⭐️ dari {rating_count} pengguna</code>\n"
-            if release := sop.select('li[data-testid="title-details-releasedate"]'):
-                rilis = (
-                    release[0]
-                    .find(
-                        class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                    )
-                    .text
-                )
-                rilis_url = release[0].find(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )["href"]
+            if (release := title_data.get("releaseYear")) and release.get("year"):
+                rilis = str(release["year"])
+                rilis_url = f"/title/tt{movie}/releaseinfo"
                 release_date_text = rilis or "-"
                 res_str += f"<b>Rilis:</b> <a href=\"https://www.imdb.com{rilis_url}\">{rilis}</a>\n"
             genre_list = []
@@ -917,14 +1017,13 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
             else:
                 genre_text = genre_text[:-2]
             country_list = []
-            if negara := sop.select('li[data-testid="title-details-origin"]'):
-                country_items = negara[0].findAll(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )
-                country_list = [country.text for country in country_items]
+            if country_items := (title_data.get("countriesOfOrigin") or {}).get(
+                "countries", []
+            ):
+                country_list = [country.get("text") for country in country_items if country and country.get("text")]
                 country_text = "".join(
-                    f"{demoji(country.text)} #{country.text.replace(' ', '_').replace('-', '_')}, "
-                    for country in country_items
+                    f"{demoji(country)} #{country.replace(' ', '_').replace('-', '_')}, "
+                    for country in country_list
                 )
                 res_str += f"<b>Negara:</b> {country_text[:-2]}\n"
             if country_text == "-":
@@ -932,14 +1031,13 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
             else:
                 country_text = country_text[:-2]
             language_list = []
-            if bahasa := sop.select('li[data-testid="title-details-languages"]'):
-                language_items = bahasa[0].findAll(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )
-                language_list = [lang.text for lang in language_items]
+            if language_items := (title_data.get("spokenLanguages") or {}).get(
+                "spokenLanguages", []
+            ):
+                language_list = [lang.get("text") for lang in language_items if lang and lang.get("text")]
                 language_text = "".join(
-                    f"#{lang.text.replace(' ', '_').replace('-', '_')}, "
-                    for lang in language_items
+                    f"#{lang.replace(' ', '_').replace('-', '_')}, "
+                    for lang in language_list
                 )
                 res_str += f"<b>Bahasa:</b> {language_text[:-2]}\n"
             if language_text == "-":
@@ -996,12 +1094,8 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                 )
             if keyword_text != "-":
                 keyword_text = keyword_text[:-2]
-            if award := sop.select('li[data-testid="award_information"]'):
-                awards = (
-                    award[0]
-                    .find(class_="ipc-metadata-list-item__list-content-item")
-                    .text
-                )
+            if nominations := (title_data.get("nominations") or {}).get("total"):
+                awards = f"{nominations} nominasi"
                 awards_text = (await gtranslate(awards, "auto", "id")).text or "-"
                 res_str += f"<b>🏆 Penghargaan:</b>\n<blockquote expandable><code>{awards_text}</code></blockquote>\n"
             else:
@@ -1245,12 +1339,8 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
         try:
             await query.message.edit_msg("<i>⏳ Getting IMDb source..</i>")
             imdb_url = f"https://m.imdb.com/title/tt{movie}/"
-            resp = await fetch.get(imdb_url)
-            resp.raise_for_status()
-            sop = BeautifulSoup(resp, "lxml")
-            r_json = json.loads(
-                sop.find("script", attrs={"type": "application/ld+json"}).contents[0]
-            )
+            title_data = await _fetch_imdb_title_details(movie)
+            r_json = _graphql_to_legacy_json(title_data)
             ott = await search_jw(
                 r_json.get("alternateName") or r_json.get("name"), "US"
             )
@@ -1274,22 +1364,14 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
             rilis = "-"
             rilis_url = ""
             summary = ""
-            tahun = (
-                re.findall(r"\d{4}\W\d{4}|\d{4}-?", sop.title.text)[0]
-                if re.findall(r"\d{4}\W\d{4}|\d{4}-?", sop.title.text)
-                else "N/A"
-            )
+            tahun = str((title_data.get("releaseYear") or {}).get("year") or "N/A")
             res_str += f"<b>📹 Judul:</b> <a href=\"{imdb_url}\">{r_json.get('name')} [{tahun}]</a> (<code>{typee}</code>)\n"
             if aka := r_json.get("alternateName"):
                 res_str += f"<b>📢 AKA:</b> <code>{aka}</code>\n\n"
             else:
                 res_str += "\n"
-            if durasi := sop.select('li[data-testid="title-techspec_runtime"]'):
-                durasi = (
-                    durasi[0]
-                    .find(class_="ipc-metadata-list-item__content-container")
-                    .text
-                )
+            if runtime_seconds := (title_data.get("runtime") or {}).get("seconds"):
+                durasi = _format_runtime(runtime_seconds)
                 duration_raw = durasi
                 duration_text = durasi
                 res_str += f"<b>Duration:</b> <code>{durasi}</code>\n"
@@ -1302,17 +1384,9 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                 rating_value = rating.get("ratingValue", "-")
                 rating_count = rating.get("ratingCount", "-")
                 res_str += f"<b>Rating:</b> <code>{rating_value}⭐️ from {rating_count} users</code>\n"
-            if release := sop.select('li[data-testid="title-details-releasedate"]'):
-                rilis = (
-                    release[0]
-                    .find(
-                        class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                    )
-                    .text
-                )
-                rilis_url = release[0].find(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )["href"]
+            if (release := title_data.get("releaseYear")) and release.get("year"):
+                rilis = str(release["year"])
+                rilis_url = f"/title/tt{movie}/releaseinfo"
                 release_date_text = rilis or "-"
                 res_str += f"<b>Rilis:</b> <a href=\"https://www.imdb.com{rilis_url}\">{rilis}</a>\n"
             genre_list = []
@@ -1330,14 +1404,17 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
             else:
                 genre_text = genre_text[:-2]
             country_list = []
-            if negara := sop.select('li[data-testid="title-details-origin"]'):
-                country_items = negara[0].findAll(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )
-                country_list = [country.text for country in country_items]
-                country_text = "".join(
-                    f"{demoji(country.text)} #{country.text.replace(' ', '_').replace('-', '_')}, "
+            if country_items := (title_data.get("countriesOfOrigin") or {}).get(
+                "countries", []
+            ):
+                country_list = [
+                    country.get("text")
                     for country in country_items
+                    if country and country.get("text")
+                ]
+                country_text = "".join(
+                    f"{demoji(country)} #{country.replace(' ', '_').replace('-', '_')}, "
+                    for country in country_list
                 )
                 res_str += f"<b>Country:</b> {country_text[:-2]}\n"
             if country_text == "-":
@@ -1345,14 +1422,17 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
             else:
                 country_text = country_text[:-2]
             language_list = []
-            if bahasa := sop.select('li[data-testid="title-details-languages"]'):
-                language_items = bahasa[0].findAll(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )
-                language_list = [lang.text for lang in language_items]
-                language_text = "".join(
-                    f"#{lang.text.replace(' ', '_').replace('-', '_')}, "
+            if language_items := (title_data.get("spokenLanguages") or {}).get(
+                "spokenLanguages", []
+            ):
+                language_list = [
+                    lang.get("text")
                     for lang in language_items
+                    if lang and lang.get("text")
+                ]
+                language_text = "".join(
+                    f"#{lang.replace(' ', '_').replace('-', '_')}, "
+                    for lang in language_list
                 )
                 res_str += f"<b>Language:</b> {language_text[:-2]}\n"
             if language_text == "-":
@@ -1410,12 +1490,8 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                 )
             if keyword_text != "-":
                 keyword_text = keyword_text[:-2]
-            if award := sop.select('li[data-testid="award_information"]'):
-                awards = (
-                    award[0]
-                    .find(class_="ipc-metadata-list-item__list-content-item")
-                    .text
-                )
+            if nominations := (title_data.get("nominations") or {}).get("total"):
+                awards = f"{nominations} nominations"
                 awards_text = awards or "-"
                 res_str += f"<b>🏆 Awards:</b>\n<blockquote expandable><code>{awards}</code></blockquote>\n"
             else:

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -4,7 +4,6 @@
 # * Copyright ©YasirPedia All rights reserved
 import contextlib
 import html
-import inspect
 import logging
 import re
 import sys
@@ -228,10 +227,7 @@ def _with_html_placeholders(payload: dict) -> dict:
 
 
 def _preview_kwargs(is_disabled: bool) -> dict:
-    params = inspect.signature(Client.edit_message_text).parameters
-    if "link_preview_options" in params:
-        return {"link_preview_options": {"is_disabled": is_disabled}}
-    return {"disable_web_page_preview": is_disabled}
+    return {"link_preview_options": {"is_disabled": is_disabled}}
 
 
 def render_imdb_template_with_buttons(template: str, payload: dict):

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -13,6 +13,7 @@ from urllib.parse import quote_plus
 import httpx
 from pykeyboard import InlineButton, InlineKeyboard
 from pyrogram import Client, enums
+from pyrogram import types as pyro_types
 from pyrogram.errors import (
     ListenerTimeout,
     MediaCaptionTooLong,
@@ -227,7 +228,11 @@ def _with_html_placeholders(payload: dict) -> dict:
 
 
 def _preview_kwargs(is_disabled: bool) -> dict:
-    return {"link_preview_options": {"is_disabled": is_disabled}}
+    return {
+        "link_preview_options": pyro_types.LinkPreviewOptions(
+            is_disabled=is_disabled
+        )
+    }
 
 
 def render_imdb_template_with_buttons(template: str, payload: dict):

--- a/misskaty/plugins/inline_search.py
+++ b/misskaty/plugins/inline_search.py
@@ -14,6 +14,7 @@ from bs4 import BeautifulSoup
 from pykeyboard import InlineButton, InlineKeyboard
 from pyrogram import __version__ as pyrover
 from pyrogram import enums, filters
+from pyrogram import types as pyro_types
 from pyrogram.errors import MessageIdInvalid, MessageNotModified
 from pyrogram.types import (
     InlineKeyboardButton,
@@ -123,7 +124,11 @@ def _with_html_placeholders(payload: dict) -> dict:
 
 
 def _preview_kwargs(is_disabled: bool) -> dict:
-    return {"link_preview_options": {"is_disabled": is_disabled}}
+    return {
+        "link_preview_options": pyro_types.LinkPreviewOptions(
+            is_disabled=is_disabled
+        )
+    }
 
 
 @app.on_inline_query()
@@ -181,7 +186,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                 description="Check Bot's Stats",
                 thumb_url="https://yt3.ggpht.com/ytc/AMLnZu-zbtIsllERaGYY8Aecww3uWUASPMjLUUEt7ecu=s900-c-k-c0x00ffffff-no-rj",
                 input_message_content=InputTextMessageContent(
-                    msg, disable_web_page_preview=True
+                    msg, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True)
                 ),
                 reply_markup=btn,
             ),
@@ -195,7 +200,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                     description="New Calculator",
                     input_message_content=InputTextMessageContent(
                         message_text=f"Made by @{self.me.username}",
-                        disable_web_page_preview=True,
+                        link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
                     ),
                     reply_markup=calc_btn(inline_query.from_user.id),
                 )
@@ -208,7 +213,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                     title="Answer",
                     description=f"Result: {result}",
                     input_message_content=InputTextMessageContent(
-                        message_text=f"{data} = {result}", disable_web_page_preview=True
+                        message_text=f"{data} = {result}", link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True)
                     ),
                 )
             ]
@@ -268,7 +273,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                         input_message_content=InputTextMessageContent(
                             message_text=msg,
                             parse_mode=enums.ParseMode.HTML,
-                            disable_web_page_preview=True,
+                            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
                         ),
                         url=link,
                         description=description,
@@ -308,7 +313,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                         input_message_content=InputTextMessageContent(
                             message_text=msg,
                             parse_mode=enums.ParseMode.HTML,
-                            disable_web_page_preview=True,
+                            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
                         ),
                         url=link,
                         description=description,
@@ -355,7 +360,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                     input_message_content=InputTextMessageContent(
                         message_text=message_text,
                         parse_mode=enums.ParseMode.HTML,
-                        disable_web_page_preview=False,
+                        link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=False),
                     ),
                     url=link,
                     description=snippet,
@@ -500,7 +505,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                     input_message_content=InputTextMessageContent(
                         message_text=message_text,
                         parse_mode=enums.ParseMode.HTML,
-                        disable_web_page_preview=False,
+                        link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=False),
                     ),
                     url=link,
                     description=deskripsi,
@@ -542,7 +547,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                     input_message_content=InputTextMessageContent(
                         message_text=message_text,
                         parse_mode=enums.ParseMode.HTML,
-                        disable_web_page_preview=False,
+                        link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=False),
                     ),
                     url=link,
                     description=deskripsi,
@@ -598,7 +603,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                     input_message_content=InputTextMessageContent(
                         message_text=message_text,
                         parse_mode=enums.ParseMode.HTML,
-                        disable_web_page_preview=False,
+                        link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=False),
                     ),
                     url=link,
                     description=deskripsi,
@@ -695,7 +700,7 @@ async def inline_menu(self, inline_query: InlineQuery):
                         input_message_content=InputTextMessageContent(
                             message_text=message_text,
                             parse_mode=enums.ParseMode.HTML,
-                            disable_web_page_preview=disable_web_preview,
+                            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
                         ),
                     )
                 )

--- a/misskaty/plugins/inline_search.py
+++ b/misskaty/plugins/inline_search.py
@@ -3,6 +3,7 @@
 # * @projectName   MissKatyPyro
 # * Copyright ©YasirPedia All rights reserved
 import html
+import inspect
 import json
 import re
 import traceback
@@ -120,6 +121,13 @@ def _with_html_placeholders(payload: dict) -> dict:
         if isinstance(value, str):
             enriched[f"{key}_html"] = html.escape(value)
     return enriched
+
+
+def _preview_kwargs(is_disabled: bool) -> dict:
+    params = inspect.signature(app.edit_message_text).parameters
+    if "link_preview_options" in params:
+        return {"link_preview_options": {"is_disabled": is_disabled}}
+    return {"disable_web_page_preview": is_disabled}
 
 
 @app.on_inline_query()
@@ -758,7 +766,7 @@ async def imdb_inl(_, query):
                 await query.edit_message_text(
                     "⏳ <i>Permintaan kamu sedang diproses.. </i>",
                     parse_mode=enums.ParseMode.HTML,
-                    disable_web_page_preview=True,
+                    **_preview_kwargs(True),
                 )
             url = f"https://m.imdb.com/title/{movie}/"
             title_data = await _fetch_imdb_title_details(movie.replace("tt", ""))
@@ -1075,7 +1083,7 @@ async def imdb_inl(_, query):
                     res_str,
                     parse_mode=enums.ParseMode.HTML,
                     reply_markup=markup,
-                    disable_web_page_preview=disable_web_preview,
+                    **_preview_kwargs(disable_web_preview),
                 )
         except (MessageNotModified, MessageIdInvalid):
             pass
@@ -1087,7 +1095,7 @@ async def imdb_inl(_, query):
                 await query.edit_message_text(
                     f"<b>ERROR:</b>\n<code>{exc}</code>",
                     parse_mode=enums.ParseMode.HTML,
-                    disable_web_page_preview=True,
+                    **_preview_kwargs(True),
                 )
     else:
         await query.answer("⚠️ Akses Ditolak!", True)

--- a/misskaty/plugins/inline_search.py
+++ b/misskaty/plugins/inline_search.py
@@ -28,6 +28,11 @@ from database.imdb_db import get_imdb_by, get_imdb_layout_fields, get_imdb_templ
 from misskaty import BOT_USERNAME, app, user
 from misskaty.helper import GENRES_EMOJI, fetch, gtranslate, post_to_telegraph, search_jw
 from misskaty.plugins.dev import shell_exec
+from misskaty.plugins.imdb_search import (
+    _fetch_imdb_title_details,
+    _format_runtime,
+    _graphql_to_legacy_json,
+)
 from misskaty.plugins.misc_tools import calc_btn
 from misskaty.vars import USER_SESSION
 from utils import demoji
@@ -756,11 +761,8 @@ async def imdb_inl(_, query):
                     disable_web_page_preview=True,
                 )
             url = f"https://m.imdb.com/title/{movie}/"
-            resp = await fetch.get(url)
-            sop = BeautifulSoup(resp, "lxml")
-            r_json = json.loads(
-                sop.find("script", attrs={"type": "application/ld+json"}).contents[0]
-            )
+            title_data = await _fetch_imdb_title_details(movie.replace("tt", ""))
+            r_json = _graphql_to_legacy_json(title_data)
             ott = await search_jw(r_json.get("alternateName") or r_json["name"], "ID")
             template = await get_imdb_template(query.from_user.id)
             imdb_by = await get_imdb_by(query.from_user.id) or f"@{app.me.username}"
@@ -782,11 +784,7 @@ async def imdb_inl(_, query):
             rilis = "-"
             rilis_url = ""
             summary = ""
-            tahun = (
-                re.findall(r"\d{4}\W\d{4}|\d{4}-?", sop.title.text)[0]
-                if re.findall(r"\d{4}\W\d{4}|\d{4}-?", sop.title.text)
-                else "N/A"
-            )
+            tahun = str((title_data.get("releaseYear") or {}).get("year") or "N/A")
             res_str += f"<b>📹 Judul:</b> <a href=\"{url}\">{r_json['name']} [{tahun}]</a> (<code>{typee}</code>)\n"
             if r_json.get("alternateName"):
                 res_str += (
@@ -794,12 +792,8 @@ async def imdb_inl(_, query):
                 )
             else:
                 res_str += "\n"
-            if durasi := sop.select('li[data-testid="title-techspec_runtime"]'):
-                durasi = (
-                    durasi[0]
-                    .find(class_="ipc-metadata-list-item__content-container")
-                    .text
-                )
+            if runtime_seconds := (title_data.get("runtime") or {}).get("seconds"):
+                durasi = _format_runtime(runtime_seconds)
                 duration_raw = durasi
                 duration_text = (await gtranslate(durasi, "auto", "id")).text
                 res_str += f"<b>Durasi:</b> <code>{duration_text}</code>\n"
@@ -808,17 +802,9 @@ async def imdb_inl(_, query):
                 res_str += f"<b>Kategori:</b> <code>{r_json['contentRating']}</code> \n"
             if r_json.get("aggregateRating"):
                 res_str += f"<b>Peringkat:</b> <code>{r_json['aggregateRating']['ratingValue']}⭐️ dari {r_json['aggregateRating']['ratingCount']} pengguna</code> \n"
-            if release := sop.select('li[data-testid="title-details-releasedate"]'):
-                rilis = (
-                    release[0]
-                    .find(
-                        class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                    )
-                    .text
-                )
-                rilis_url = release[0].find(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )["href"]
+            if (release := title_data.get("releaseYear")) and release.get("year"):
+                rilis = str(release["year"])
+                rilis_url = f"/title/{movie}/releaseinfo"
                 release_date_text = rilis or "-"
                 res_str += f"<b>Rilis:</b> <a href=\"https://www.imdb.com{rilis_url}\">{rilis}</a>\n"
             genre_list = []
@@ -840,14 +826,17 @@ async def imdb_inl(_, query):
             else:
                 genre_text = genre_text[:-2]
             country_list = []
-            if negara := sop.select('li[data-testid="title-details-origin"]'):
-                country_items = negara[0].findAll(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )
-                country_list = [country.text for country in country_items]
-                country_text = "".join(
-                    f"{demoji(country.text)} #{country.text.replace(' ', '_').replace('-', '_')}, "
+            if country_items := (title_data.get("countriesOfOrigin") or {}).get(
+                "countries", []
+            ):
+                country_list = [
+                    country.get("text")
                     for country in country_items
+                    if country and country.get("text")
+                ]
+                country_text = "".join(
+                    f"{demoji(country)} #{country.replace(' ', '_').replace('-', '_')}, "
+                    for country in country_list
                 )
                 res_str += f"<b>Negara:</b> {country_text[:-2]}\n"
             if country_text == "-":
@@ -855,14 +844,15 @@ async def imdb_inl(_, query):
             else:
                 country_text = country_text[:-2]
             language_list = []
-            if bahasa := sop.select('li[data-testid="title-details-languages"]'):
-                language_items = bahasa[0].findAll(
-                    class_="ipc-metadata-list-item__list-content-item ipc-metadata-list-item__list-content-item--link"
-                )
-                language_list = [lang.text for lang in language_items]
+            if language_items := (title_data.get("spokenLanguages") or {}).get(
+                "spokenLanguages", []
+            ):
+                language_list = [
+                    lang.get("text") for lang in language_items if lang and lang.get("text")
+                ]
                 language_text = "".join(
-                    f"#{lang.text.replace(' ', '_').replace('-', '_')}, "
-                    for lang in language_items
+                    f"#{lang.replace(' ', '_').replace('-', '_')}, "
+                    for lang in language_list
                 )
                 res_str += f"<b>Bahasa:</b> {language_text[:-2]}\n"
             if language_text == "-":
@@ -915,12 +905,8 @@ async def imdb_inl(_, query):
                 )
             if keyword_text != "-":
                 keyword_text = keyword_text[:-2]
-            if award := sop.select('li[data-testid="award_information"]'):
-                awards = (
-                    award[0]
-                    .find(class_="ipc-metadata-list-item__list-content-item")
-                    .text
-                )
+            if nominations := (title_data.get("nominations") or {}).get("total"):
+                awards = f"{nominations} nominasi"
                 awards_text = (await gtranslate(awards, "auto", "id")).text or "-"
                 res_str += f"<b>🏆 Penghargaan:</b>\n<blockquote expandable><code>{awards_text}</code></blockquote>\n"
             else:

--- a/misskaty/plugins/inline_search.py
+++ b/misskaty/plugins/inline_search.py
@@ -3,7 +3,6 @@
 # * @projectName   MissKatyPyro
 # * Copyright ©YasirPedia All rights reserved
 import html
-import inspect
 import json
 import re
 import traceback
@@ -124,10 +123,7 @@ def _with_html_placeholders(payload: dict) -> dict:
 
 
 def _preview_kwargs(is_disabled: bool) -> dict:
-    params = inspect.signature(app.edit_message_text).parameters
-    if "link_preview_options" in params:
-        return {"link_preview_options": {"is_disabled": is_disabled}}
-    return {"disable_web_page_preview": is_disabled}
+    return {"link_preview_options": {"is_disabled": is_disabled}}
 
 
 @app.on_inline_query()


### PR DESCRIPTION
### Motivation

- Replace fragile HTML scraping with IMDb GraphQL to get more reliable and richer title data.
- Standardize parsing into a legacy-like JSON shape so existing templates and UI code keep working.

### Description

- Introduce GraphQL access: add `IMDB_GRAPHQL_URL`, `IMDB_GRAPHQL_HEADERS`, and `IMDB_TITLE_QUERY`, and implement `_fetch_imdb_title_details` to retrieve title data via `httpx`.
- Add `_graphql_to_legacy_json` to convert GraphQL response into the existing legacy JSON shape and `_format_runtime` to normalize runtime output.
- Refactor IMDb handlers to use the GraphQL helpers instead of HTML scraping with `BeautifulSoup`, updating mappings for runtime, release year, countries, languages, nominations, trailer, and principal credits (director/writer/actor).
- Update `inline_search` to import the new helper functions and remove legacy scraping paths; remove unused imports in `imdb_search` (e.g. `bs4`, `json`).

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a4bb087e2c8328a6cbd40b4465d81b)

## Summary by Sourcery

Replace IMDb HTML scraping with a GraphQL-based title lookup and adapt existing handlers to consume the new data shape.

New Features:
- Add a GraphQL-based IMDb title details fetcher using httpx and a reusable title query.
- Introduce helpers to convert IMDb GraphQL responses into the existing legacy JSON structure and to format runtimes.

Enhancements:
- Refactor IMDb detail callbacks and inline search to use the GraphQL helpers instead of BeautifulSoup HTML scraping while preserving existing output formatting.
- Simplify extraction of release year, countries, languages, and awards by reading them directly from GraphQL data rather than parsing HTML.
- Remove now-unneeded HTML scraping code and related imports from IMDb search and inline search handlers.