### PR TITLE
Add Metascore and Awards to IMDb GraphQL parsing and templates

### DIFF
--- a/misskaty/helper/imdb_graphql.py
+++ b/misskaty/helper/imdb_graphql.py
@@ -29,6 +29,7 @@ IMDB_TITLE_QUERY = """query GetTitle($id: ID!) {
     releaseDate { day month year }
     runtime { seconds }
     ratingsSummary { aggregateRating voteCount }
+    metacritic { metascore { score } }
     spokenLanguages { spokenLanguages { text } }
     countriesOfOrigin { countries { text } }
     certificate { rating }
@@ -41,6 +42,16 @@ IMDB_TITLE_QUERY = """query GetTitle($id: ID!) {
     }
     keywords(first: 20) { edges { node { text } } }
     latestTrailer { playbackURLs { url } }
+    prestigiousAwardSummary {
+      wins
+      nominations
+      award { text }
+    }
+    awardNominations {
+      total
+      wins
+      excludingWins
+    }
   }
 }"""
 
@@ -116,6 +127,23 @@ async def get_imdb_details_graphql(title_id: str):
     runtime_seconds = (payload.get("runtime") or {}).get("seconds")
     duration_text = f"{runtime_seconds // 60} min" if isinstance(runtime_seconds, int) and runtime_seconds > 0 else None
 
+    award_summary = payload.get("prestigiousAwardSummary") or {}
+    award_nominations = payload.get("awardNominations") or {}
+    award_name = ((award_summary.get("award") or {}).get("text") or "").strip()
+    wins = award_summary.get("wins")
+    nominations = award_summary.get("nominations")
+    total_nominations = award_nominations.get("total")
+    award_bits = []
+    if isinstance(wins, int):
+        award_bits.append(f"{wins} win{'s' if wins != 1 else ''}")
+    if isinstance(nominations, int):
+        award_bits.append(f"{nominations} nomination{'s' if nominations != 1 else ''}")
+    elif isinstance(total_nominations, int):
+        award_bits.append(f"{total_nominations} nomination{'s' if total_nominations != 1 else ''}")
+    if award_name:
+        award_bits.append(award_name)
+    awards_text = ", ".join(award_bits) if award_bits else None
+
     return {
         "name": (payload.get("titleText") or {}).get("text"),
         "alternateName": (payload.get("originalTitleText") or {}).get("text"),
@@ -138,6 +166,7 @@ async def get_imdb_details_graphql(title_id: str):
             "ratingValue": (payload.get("ratingsSummary") or {}).get("aggregateRating"),
             "ratingCount": (payload.get("ratingsSummary") or {}).get("voteCount"),
         },
+        "metascore": (((payload.get("metacritic") or {}).get("metascore") or {}).get("score")),
         "genre": [
             (item or {}).get("text")
             for item in (payload.get("genres") or {}).get("genres", [])
@@ -155,6 +184,7 @@ async def get_imdb_details_graphql(title_id: str):
             for edge in (payload.get("keywords") or {}).get("edges", [])
             if (edge.get("node") or {}).get("text")
         ),
+        "awards": awards_text,
         "director": _people("Director"),
         "creator": _people("Writers", "Writer", "Creator"),
         "actor": _people("Stars", "Cast"),

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -273,7 +273,7 @@ async def imdb_template(_, ctx: Message):
             "{genres_list}, {countries}, {countries_list}, {languages}, "
             "{languages_list}, {directors}, {writers}, {cast}, {plot}, {keywords}, "
             "{keywords_list}, {awards}, {availability}, {ott}, {imdb_by}, "
-            "{imdb_url}, {trailer_url}, {poster_url}, {imdb_code}, {locale}"
+            "{imdb_url}, {trailer_url}, {poster_url}, {imdb_code}, {metascore}, {locale}"
         )
         if template:
             return await ctx.reply(
@@ -495,6 +495,7 @@ async def imdb_template_menu(_, query: CallbackQuery):
         "• <code>{trailer_url}</code> - URL trailer\n"
         "• <code>{poster_url}</code> - URL poster\n"
         "• <code>{imdb_code}</code> - ID IMDb (misal tt1234567)\n"
+        "• <code>{metascore}</code> - Skor Metacritic\n"
         "• <code>{locale}</code> - Kode bahasa (id/en)\n"
         "• <code>{nama_placeholder_html}</code> - versi aman HTML (otomatis tersedia)\n"
         "  Contoh: <code>{plot_html}</code>\n\n"
@@ -1039,6 +1040,7 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                     "trailer_url": trailer_url,
                     "poster_url": poster_url,
                     "imdb_code": imdb_code,
+                    "metascore": str(r_json.get("metascore") or "-"),
                     "locale": "id",
                     "link": imdb_url,
                     "movie_type": typee or "-",
@@ -1432,6 +1434,7 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                     "trailer_url": trailer_url,
                     "poster_url": poster_url,
                     "imdb_code": imdb_code,
+                    "metascore": str(r_json.get("metascore") or "-"),
                     "locale": "en",
                     "link": imdb_url,
                     "movie_type": typee or "-",

--- a/misskaty/plugins/inline_search.py
+++ b/misskaty/plugins/inline_search.py
@@ -962,6 +962,7 @@ async def imdb_inl(_, query):
                     "trailer_url": trailer_url,
                     "poster_url": poster_url,
                     "imdb_code": imdb_code,
+                    "metascore": str(r_json.get("metascore") or "-"),
                     "locale": "id",
                     "link": url,
                     "movie_type": typee or "-",


### PR DESCRIPTION
### Motivation
- Expose Metacritic score and richer awards information from IMDb GraphQL responses so templates and outputs can show metascore and award summaries.
- Provide template placeholder support for `metascore` so users can include it in custom IMDb message templates.

### Description
- Extended the GraphQL query (`IMDB_TITLE_QUERY`) to request `metacritic { metascore { score } }`, `prestigiousAwardSummary` and `awardNominations` fields.
- Parse and surface `metascore` into the returned details (`metascore` key) and add logic to build a human-readable `awards` string from `prestigiousAwardSummary`/`awardNominations`.
- Added `metascore` placeholder support to the IMDb template help text and included `metascore` in template rendering contexts in `imdb_search.py`, `inline_search.py`, and related callbacks.

### Testing
- Ran the project's automated test suite with `pytest -q` and the tests passed.
- Ran the project's linter (`flake8`) for style issues and no new problems were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a55f262950832882124085d310cb83)

## Summary by Sourcery

Expose Metacritic metascore and awards information from IMDb GraphQL and wire them through to templates and callbacks so they can be rendered in IMDb-related messages.

New Features:
- Add Metacritic metascore and detailed awards fields to the IMDb GraphQL query and parsed title details.
- Support a new {metascore} placeholder in IMDb message templates and inline/ID callbacks for rendering Metacritic scores.