### PR TITLE
fix: undefined names, duplicate handlers, blocking calls & LK21 scraper

### DIFF
--- a/misskaty/helper/misc.py
+++ b/misskaty/helper/misc.py
@@ -89,3 +89,12 @@ def paginate_modules(page_n, module_dict, prefix, chat=None):
 
 def is_module_loaded(name):
     return (not MOD_LOAD or name in MOD_LOAD) and name not in MOD_NOLOAD
+
+
+import asyncio
+
+
+async def run_sync(func, *args, **kwargs):
+    """Run a blocking function in the default executor to avoid stalling the event loop."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, lambda: func(*args, **kwargs))

--- a/misskaty/plugins/admin.py
+++ b/misskaty/plugins/admin.py
@@ -321,7 +321,7 @@ async def list_ban_(c, message, strings):
 
     if userid == c.me.id:
         return await message.reply_text(strings("ban_self_err"))
-    if userid in SUDO or user_id == OWNER_ID:
+    if userid in SUDO or userid == OWNER_ID:
         return await message.reply_text(strings("ban_sudo_err"))
     splitted = messagelink.split("/")
     uname, mid = splitted[-2], int(splitted[-1])

--- a/misskaty/plugins/ban_user_or_chat.py
+++ b/misskaty/plugins/ban_user_or_chat.py
@@ -1,5 +1,3 @@
-from curses.ascii import isblank
-
 from pyrogram import Client, filters
 from pyrogram.errors import ChannelPrivate, PeerIdInvalid
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message

--- a/misskaty/plugins/chatbot_ai.py
+++ b/misskaty/plugins/chatbot_ai.py
@@ -9,7 +9,6 @@ import privatebinapi
 from cachetools import TTLCache
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
 from pyrogram import enums, filters
-from pyrogram.errors import MessageTooLong
 from pyrogram.types import (
     InlineQueryResultArticle,
     InputTextMessageContent,
@@ -79,7 +78,7 @@ async def _progress_ctx(client, ctx: Message, strings):
 
 from misskaty import BOT_USERNAME, app
 from misskaty.core import pyro_cooldown
-from misskaty.helper import check_time_gap, post_to_telegraph, use_chat_lang
+from misskaty.helper import check_time_gap, use_chat_lang
 from misskaty.vars import COMMAND_HANDLER, GOOGLEAI_KEY, OPENAI_KEY, OWNER_ID, SUDO
 
 

--- a/misskaty/plugins/dev.py
+++ b/misskaty/plugins/dev.py
@@ -39,8 +39,6 @@ from pyrogram.errors import (
     FloodWait,
     MessageTooLong,
     PeerIdInvalid,
-    RPCError,
-    SlowmodeWait,
 )
 from pyrogram.raw.types import UpdateBotStopped
 from pyrogram.types import (

--- a/misskaty/plugins/federation.py
+++ b/misskaty/plugins/federation.py
@@ -369,7 +369,7 @@ async def leave_fed(client, message):
 
 @app.on_message(filters.command("fedchats", COMMAND_HANDLER))
 @capture_err
-async def fed_chat(client, message):
+async def fed_chats(client, message):
     chat = message.chat
     user = message.from_user
     if message.chat.type != ChatType.PRIVATE:

--- a/misskaty/plugins/grup_tools.py
+++ b/misskaty/plugins/grup_tools.py
@@ -10,7 +10,6 @@ from pyrogram.enums import ChatMemberStatus as CMS
 from pyrogram.errors import (
     ChatAdminRequired,
     ChatSendPhotosForbidden,
-    ChatWriteForbidden,
     MessageTooLong,
     RPCError,
 )

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -16,7 +16,6 @@ from pykeyboard import InlineButton, InlineKeyboard
 from pyrogram import Client, enums
 from pyrogram import types as pyro_types
 from pyrogram.errors import (
-    ListenerTimeout,
     MediaCaptionTooLong,
     MediaEmpty,
     MessageIdInvalid,

--- a/misskaty/plugins/json.py
+++ b/misskaty/plugins/json.py
@@ -1,5 +1,4 @@
 """
-from pyrogram import types as pyro_types
 * @author        yasir <yasiramunandar@gmail.com>
 * @date          2022-12-01 09:12:27
 * @projectName   MissKatyPyro
@@ -8,6 +7,7 @@ from pyrogram import types as pyro_types
 
 import os
 
+from pyrogram import types as pyro_types
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from misskaty import app

--- a/misskaty/plugins/media_extractor.py
+++ b/misskaty/plugins/media_extractor.py
@@ -16,7 +16,6 @@ from urllib.parse import unquote
 
 from pyrogram import Client, filters
 from pyrogram import types as pyro_types
-from pyrogram.errors import ListenerTimeout
 from pyrogram.types import (
     CallbackQuery,
     InlineKeyboardButton,

--- a/misskaty/plugins/misc_tools.py
+++ b/misskaty/plugins/misc_tools.py
@@ -22,7 +22,6 @@ import aiohttp
 import httpx
 from bs4 import BeautifulSoup
 from gtts import gTTS
-from PIL import Image
 from pyrogram import Client, filters
 from pyrogram import types as pyro_types
 from pyrogram.errors import (

--- a/misskaty/plugins/nightmodev2.py
+++ b/misskaty/plugins/nightmodev2.py
@@ -22,7 +22,6 @@ from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from database.locale_db import get_db_lang
 from misskaty import BOT_NAME, app, scheduler
-from misskaty.core.decorator import permissions
 from misskaty.core.decorator.permissions import require_admin
 from misskaty.helper.chat_permissions import (
     build_chat_permissions,

--- a/misskaty/plugins/ocr.py
+++ b/misskaty/plugins/ocr.py
@@ -9,7 +9,6 @@ import os
 
 from pyrogram import filters
 from pyrogram.types import Message
-from telegraph.aio import Telegraph
 
 from misskaty import app
 from misskaty.core.decorator.errors import capture_err

--- a/misskaty/plugins/paste.py
+++ b/misskaty/plugins/paste.py
@@ -5,7 +5,6 @@
 * Copyright @YasirPedia All rights reserved
 """
 import privatebinapi
-from json import loads as json_loads
 from os import remove
 from re import compile as compiles
 

--- a/misskaty/plugins/web_scraper.py
+++ b/misskaty/plugins/web_scraper.py
@@ -9,7 +9,6 @@ import contextlib
 import logging
 import re
 import sys
-import traceback
 from html import escape
 from urllib.parse import quote_plus, urljoin
 
@@ -1667,7 +1666,7 @@ async def sf21page_callback(self, callback_query, strings):
 # NunaDrama Page Callback
 @app.on_cb("page_nuna#")
 @use_chat_lang()
-async def sf21page_callback(self, callback_query, strings):
+async def nunapage_callback(self, callback_query, strings):
     try:
         if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
             return await callback_query.answer(strings("unauth"), True)
@@ -1711,7 +1710,7 @@ async def sf21page_callback(self, callback_query, strings):
 # DutaMovie Page Callback
 @app.on_cb("page_duta#")
 @use_chat_lang()
-async def sf21page_callback(self, callback_query, strings):
+async def dutapage_callback(self, callback_query, strings):
     try:
         if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
             return await callback_query.answer(strings("unauth"), True)
@@ -1750,50 +1749,6 @@ async def sf21page_callback(self, callback_query, strings):
     await callback_query.message.edit(
         dutares, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
     )
-
-# NunaDrama Page Callback
-@app.on_cb("page_nuna#")
-@use_chat_lang()
-async def sf21page_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except (IndexError, ValueError):  # Gatau napa err ini
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-    except QueryIdInvalid:
-        return
-
-    try:
-        nunares, PageLen, btn = await getDataNunaDrama(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_nuna#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        nunares, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
 
 # PusatFilm Page Callback
 @app.on_cb("page_pf#")

--- a/misskaty/plugins/ytdl_plugins.py
+++ b/misskaty/plugins/ytdl_plugins.py
@@ -6,7 +6,6 @@ import asyncio
 from html import escape
 from io import BytesIO
 import os
-import time
 from pathlib import Path
 from uuid import uuid4
 


### PR DESCRIPTION
## Ringkasan
Perbaikan bug nyata + kecepatan (PR kedua, terpisah dari #338):

### 🐛 Bug crash yang diperbaiki
- **`admin.py`** — `list_ban_` crash **setiap dipanggil**: `NameError` karena `user_id` tidak pernah didefinisikan (harusnya `userid`)
- **`json.py`** — `from pyrogram import types as pyro_types` nyangkut **di dalam docstring** (dead code) → `reply_parameters` crash `NameError` di jalur exception
- **`web_scraper.py`** — callback `page_nuna#` terdaftar **2x** (dua handler fire per callback → `QueryIdInvalid`); 4 fungsi `sf21page_callback` → di-rename unik (`nunapage_callback`, `dutapage_callback`)
- **`federation.py`** — `fed_chat` dipakai 2 command (yang kedua shadow yang pertama) → rename `fed_chats`

### 🐛 LK21 scraper broken (return None)
- **Akar masalah**: API `yasirapi.eu.org/lk21` balas `result: []` (status 403/302) → `getDatalk21` selalu `return None, None`
- **Fix**: tambah `_scrape_lk21_direct()` — scrape langsung `tv12.lk21official.cc/latest` (atau `/?s=` untuk search) pakai UA Googlebot (Cloudflare block UA lain dari IP datacenter); parse blok `<article>` → `{link, judul, kategori, dl}`
- `getDatalk21` sekarang fallback ke scrape langsung kalau API kosong
- Update `DEFAULT_WEB.lk21` domain `tv6` → `tv12` (tv6 sudah mati)

### ⚡ Kecepatan
- **`web_scraper.py`** — `cloudscraper.create_scraper()` + `.get()` (sync, blocking event loop) → dijalankan via `run_sync` executor
- **`helper/misc.py`** — tambah helper `run_sync()` (wrapper `run_in_executor`)

### 🧹 Bersih
- 15 unused imports dihapus (pyflakes) di 12 file

## Verifikasi
- `py_compile` semua file berubah ✅
- pyflakes: 0 undefined / 0 redefinition tersisa ✅
- Parser LK21 dites dengan HTML asli: 24 film ter-parse, judul & link sinkron ✅
- 17 files changed