### PR TITLE
feat: chatbot AI via 9Router + rich message support

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -91,6 +91,10 @@ Jika Anda ingin membantu saya memperbaiki beberapa kesalahan di bot saya, Anda d
 * `OPENAI_API`: Dapatkan dari Web OpenAI (Deprecated Temporary)
 * `GOOGLE_API`: Pelajari dari ini https://github.com/dsdanielpark/Bard-API untuk mendapatkan cookies dan set sebagai api key.
 * `CURRENCY_API`: Dapatkan API Key di https://app.exchangerate-api.com/sign-up
+* `NINE_ROUTER_API_KEY`: API key gateway [9Router](https://9router.yasirweb.eu.org) untuk command chatbot `/ai` dan `/ask` (API OpenAI-compatible). **Wajib untuk plugin ChatBot.**
+* `NINE_ROUTER_BASE_URL`: Base URL 9Router. Default `https://9router.yasirweb.eu.org/v1` (opsional).
+* `NINE_ROUTER_MODEL_AI`: Model untuk `/ai`. Default `oc/mimo-v2.5-free` (opsional).
+* `NINE_ROUTER_MODEL_ASK`: Model untuk `/ask` & guest mode. Default `oc/deepseek-v4-flash-free` (opsional).
 
 ## [7] Tutorial Deploy (Recommended using Docker/Docker Compose)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ If you want help me fixing some error in my bot, you can make pull request to th
 * `OPENAI_API`: Create personal access token from github, and set as this env. Make sure you have access to Github Model.
 * `GOOGLEAI_KEY`: Learn how to get api key from this https://ai.google.dev/tutorials/python_quickstart?hl=en.
 * `CURRENCY_API`: Get API Key from https://app.exchangerate-api.com/sign-up
+* `NINE_ROUTER_API_KEY`: API key for the [9Router](https://9router.yasirweb.eu.org) gateway used by `/ai` and `/ask` chatbot commands (OpenAI-compatible API). **Required for ChatBot plugin.**
+* `NINE_ROUTER_BASE_URL`: 9Router base URL. Default `https://9router.yasirweb.eu.org/v1` (optional).
+* `NINE_ROUTER_MODEL_AI`: Model used by `/ai`. Default `oc/mimo-v2.5-free` (optional).
+* `NINE_ROUTER_MODEL_ASK`: Model used by `/ask` & guest mode. Default `oc/deepseek-v4-flash-free` (optional).
 
 ## [7] Tutorial Deploy (Recommended using Docker/Docker Compose)
 

--- a/misskaty/plugins/chatbot_ai.py
+++ b/misskaty/plugins/chatbot_ai.py
@@ -175,45 +175,36 @@ def _is_private_chat(ctx: Message) -> bool:
     return getattr(ctx.chat, "type", None) == enums.ChatType.PRIVATE
 
 
+async def _deliver_error(client, ctx, bmsg, err: str, rich_mode: bool):
+    """Kirim pesan error: rich message di private, edit_msg di tempat lain."""
+    if rich_mode:
+        await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
+    else:
+        await bmsg.edit_msg(err)
+
+
+async def _deliver_result(client, ctx, bmsg, text: str, strings, rich_mode: bool):
+    """Kirim hasil: rich message di private, edit_msg di tempat lain."""
+    if len(text) > 4000:
+        answerlink = await privatebinapi.send_async(
+            "https://bin.yasirweb.eu.org",
+            text=text,
+            expiration="1week",
+            formatting="markdown",
+        )
+        text = strings("answers_too_long").format(
+            answerlink=answerlink.get("full_url")
+        )
+    if rich_mode:
+        await client.send_rich_message(ctx.chat.id, InputRichMessage(html=text))
+    else:
+        await bmsg.edit_msg(text, disable_web_page_preview=True)
+
+
 async def _edit_result(client, ctx, bmsg, text: str, strings):
     """Send final answer: rich message in private, edit_msg elsewhere."""
-    if _is_private_chat(ctx):
-        if len(text) > 4000:
-            answerlink = await privatebinapi.send_async(
-                "https://bin.yasirweb.eu.org",
-                text=text,
-                expiration="1week",
-                formatting="markdown",
-            )
-            await client.send_rich_message(
-                ctx.chat.id,
-                InputRichMessage(
-                    html=strings("answers_too_long").format(
-                        answerlink=answerlink.get("full_url")
-                    )
-                ),
-            )
-        else:
-            await client.send_rich_message(
-                ctx.chat.id,
-                InputRichMessage(html=text),
-            )
-    else:
-        if len(text) > 4000:
-            answerlink = await privatebinapi.send_async(
-                "https://bin.yasirweb.eu.org",
-                text=text,
-                expiration="1week",
-                formatting="markdown",
-            )
-            await bmsg.edit_msg(
-                strings("answers_too_long").format(
-                    answerlink=answerlink.get("full_url")
-                ),
-                disable_web_page_preview=True,
-            )
-        else:
-            await bmsg.edit_msg(text, disable_web_page_preview=True)
+    rich_mode = ctx is not None and _is_private_chat(ctx)
+    await _deliver_result(client, ctx, bmsg, text, strings, rich_mode)
 
 
 async def get_openai_stream_response(
@@ -268,36 +259,23 @@ async def get_openai_stream_response(
             final = f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>"
             await _edit_result(client, ctx, bmsg, final, strings)
     except APIConnectionError as e:
-        err = f"The server could not be reached because {e.__cause__}"
-        if rich_mode:
-            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
-        else:
-            await bmsg.edit_msg(err)
+        await _deliver_error(client, ctx, bmsg, f"The server could not be reached because {e.__cause__}", rich_mode)
         return None
     except RateLimitError as e:
         err = "You're got rate limit, please try again later."
         if "billing details" in str(e):
             err = "This openai key from this bot has expired, please give openai key donation for bot owner."
-        if rich_mode:
-            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
-        else:
-            await bmsg.edit_msg(err)
+        await _deliver_error(client, ctx, bmsg, err, rich_mode)
         return None
     except APIStatusError as e:
-        err = (
-            f"Another {e.status_code} status code was received with response {e.response}"
+        await _deliver_error(
+            client, ctx, bmsg,
+            f"Another {e.status_code} status code was received with response {e.response}",
+            rich_mode,
         )
-        if rich_mode:
-            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
-        else:
-            await bmsg.edit_msg(err)
         return None
     except Exception as e:
-        err = f"ERROR: {e}"
-        if rich_mode:
-            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
-        else:
-            await bmsg.edit_msg(err)
+        await _deliver_error(client, ctx, bmsg, f"ERROR: {e}", rich_mode)
         return None
     return answer
 

--- a/misskaty/plugins/chatbot_ai.py
+++ b/misskaty/plugins/chatbot_ai.py
@@ -11,6 +11,7 @@ from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitErr
 from pyrogram import enums, filters
 from pyrogram.types import (
     InlineQueryResultArticle,
+    InputRichMessage,
     InputTextMessageContent,
     LinkPreviewOptions,
     Message,
@@ -79,7 +80,15 @@ async def _progress_ctx(client, ctx: Message, strings):
 from misskaty import BOT_USERNAME, app
 from misskaty.core import pyro_cooldown
 from misskaty.helper import check_time_gap, use_chat_lang
-from misskaty.vars import COMMAND_HANDLER, GOOGLEAI_KEY, OPENAI_KEY, OWNER_ID, SUDO
+from misskaty.vars import (
+    COMMAND_HANDLER,
+    NINE_ROUTER_API_KEY,
+    NINE_ROUTER_BASE_URL,
+    NINE_ROUTER_MODEL_AI,
+    NINE_ROUTER_MODEL_ASK,
+    OWNER_ID,
+    SUDO,
+)
 
 
 def _extract_guest_prompt(ctx: Message) -> str:
@@ -149,17 +158,79 @@ def _extract_guest_prompt(ctx: Message) -> str:
 
 __MODULE__ = "ChatBot"
 __HELP__ = """
-/ai - Generate text response from AI using Gemini AI By Google.
-/ask - Generate text response from AI using OpenAI.
+/ai - Generate text response from AI using Mimo via 9Router.
+/ask - Generate text response from AI using DeepSeek via 9Router.
 """
 
 gptai_conversations = TTLCache(maxsize=4000, ttl=24*60*60)
 gemini_conversations = TTLCache(maxsize=4000, ttl=24*60*60)
 
-async def get_openai_stream_response(is_stream, key, base_url, model, messages, bmsg, strings):
+RICH_THINKING_HTML = "<tg-thinking>🤔 <b>Mikir...</b></tg-thinking>"
+
+
+def _is_private_chat(ctx: Message) -> bool:
+    """True when we can use rich messages/drafts: private DM, not guest inline."""
+    if getattr(ctx, "guest_query_id", None):
+        return False
+    return getattr(ctx.chat, "type", None) == enums.ChatType.PRIVATE
+
+
+async def _edit_result(client, ctx, bmsg, text: str, strings):
+    """Send final answer: rich message in private, edit_msg elsewhere."""
+    if _is_private_chat(ctx):
+        if len(text) > 4000:
+            answerlink = await privatebinapi.send_async(
+                "https://bin.yasirweb.eu.org",
+                text=text,
+                expiration="1week",
+                formatting="markdown",
+            )
+            await client.send_rich_message(
+                ctx.chat.id,
+                InputRichMessage(
+                    html=strings("answers_too_long").format(
+                        answerlink=answerlink.get("full_url")
+                    )
+                ),
+            )
+        else:
+            await client.send_rich_message(
+                ctx.chat.id,
+                InputRichMessage(html=text),
+            )
+    else:
+        if len(text) > 4000:
+            answerlink = await privatebinapi.send_async(
+                "https://bin.yasirweb.eu.org",
+                text=text,
+                expiration="1week",
+                formatting="markdown",
+            )
+            await bmsg.edit_msg(
+                strings("answers_too_long").format(
+                    answerlink=answerlink.get("full_url")
+                ),
+                disable_web_page_preview=True,
+            )
+        else:
+            await bmsg.edit_msg(text, disable_web_page_preview=True)
+
+
+async def get_openai_stream_response(
+    client, is_stream, key, base_url, model, messages, bmsg, strings, ctx=None
+):
     ai = AsyncOpenAI(api_key=key, base_url=base_url)
     answer = ""
     num = 0
+    rich_mode = ctx is not None and _is_private_chat(ctx) and is_stream
+    draft_id = None
+    if rich_mode:
+        draft_id = client.rnd_id()
+        await client.send_rich_message_draft(
+            ctx.chat.id,
+            draft_id,
+            InputRichMessage(html=RICH_THINKING_HTML),
+        )
     try:
         response = await ai.chat.completions.create(
             model=model,
@@ -168,50 +239,65 @@ async def get_openai_stream_response(is_stream, key, base_url, model, messages, 
             stream=is_stream,
         )
         if not is_stream:
-            answer += response.choices[0].message.content
-            if len(answer) > 4000:
-                answerlink = await privatebinapi.send_async("https://bin.yasirweb.eu.org", text=answer, expiration="1week", formatting="markdown")
-                await bmsg.edit_msg(
-                    strings("answers_too_long").format(answerlink=answerlink.get("full_url")),
-                    disable_web_page_preview=True,
-                )
+            answer += response.choices[0].message.content or ""
+            if rich_mode:
+                await _edit_result(client, ctx, bmsg, f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>", strings)
             else:
-                await bmsg.edit_msg(f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>Gemini 2.5 Flash</code>")
+                await _edit_result(client, ctx, bmsg, f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>", strings)
         else:
             async for chunk in response:
                 if not chunk.choices or not chunk.choices[0].delta.content:
                     continue
                 num += 1
                 answer += chunk.choices[0].delta.content
-                if num == 30 and len(answer) < 4000:
-                    await bmsg.edit_msg(html.escape(answer))
-                    await asyncio.sleep(1.5)
-                    num = 0
-            if len(answer) > 4000:
-                answerlink = await privatebinapi.send_async("https://bin.yasirweb.eu.org", text=answer, expiration="1week", formatting="markdown")
-                await bmsg.edit_msg(
-                    strings("answers_too_long").format(answerlink=answerlink.get("full_url")),
-                    disable_web_page_preview=True,
-                )
-            else:
-                await bmsg.edit_msg(f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>DeepSeek</code>")
+                if rich_mode:
+                    # Streaming preview via rich draft (same draft_id = animated)
+                    try:
+                        await client.send_rich_message_draft(
+                            ctx.chat.id,
+                            draft_id,
+                            InputRichMessage(html=html.escape(answer)),
+                        )
+                    except Exception:
+                        pass
+                else:
+                    if num == 30 and len(answer) < 4000:
+                        await bmsg.edit_msg(html.escape(answer))
+                        await asyncio.sleep(1.5)
+                        num = 0
+            final = f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>"
+            await _edit_result(client, ctx, bmsg, final, strings)
     except APIConnectionError as e:
-        await bmsg.edit_msg(f"The server could not be reached because {e.__cause__}")
+        err = f"The server could not be reached because {e.__cause__}"
+        if rich_mode:
+            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
+        else:
+            await bmsg.edit_msg(err)
         return None
     except RateLimitError as e:
+        err = "You're got rate limit, please try again later."
         if "billing details" in str(e):
-            return await bmsg.edit_msg(
-                "This openai key from this bot has expired, please give openai key donation for bot owner."
-            )
-        await bmsg.edit_msg("You're got rate limit, please try again later.")
+            err = "This openai key from this bot has expired, please give openai key donation for bot owner."
+        if rich_mode:
+            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
+        else:
+            await bmsg.edit_msg(err)
         return None
     except APIStatusError as e:
-        await bmsg.edit_msg(
+        err = (
             f"Another {e.status_code} status code was received with response {e.response}"
         )
+        if rich_mode:
+            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
+        else:
+            await bmsg.edit_msg(err)
         return None
     except Exception as e:
-        await bmsg.edit_msg(f"ERROR: {e}")
+        err = f"ERROR: {e}"
+        if rich_mode:
+            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
+        else:
+            await bmsg.edit_msg(err)
         return None
     return answer
 
@@ -253,6 +339,7 @@ async def gemini_chatbot(client, ctx: Message, strings):
             prompt = prompt.strip()[len("ai "):].lstrip(" \t:-")
 
         user_content = prompt
+        model = NINE_ROUTER_MODEL_ASK  # guest mode -> deepseek
     else:
         if len(ctx.command) == 1:
             return await _reply_ctx(
@@ -263,9 +350,10 @@ async def gemini_chatbot(client, ctx: Message, strings):
                 del_in=5,
             )
         user_content = ctx.input
+        model = NINE_ROUTER_MODEL_AI  # /ai -> mimo
 
-    if not GOOGLEAI_KEY:
-        return await _reply_ctx(client, ctx, "GOOGLEAI_KEY env is missing!!!")
+    if not NINE_ROUTER_API_KEY:
+        return await _reply_ctx(client, ctx, "NINE_ROUTER_API_KEY env is missing!!!")
 
     uid = (
         ctx.guest_bot_caller_user.id
@@ -273,7 +361,7 @@ async def gemini_chatbot(client, ctx: Message, strings):
         else (ctx.from_user.id if ctx.from_user else ctx.sender_chat.id)
     )
 
-    msg = await _progress_ctx(client, ctx, strings)
+    msg = None if _is_private_chat(ctx) else await _progress_ctx(client, ctx, strings)
     if uid not in gemini_conversations:
         gemini_conversations[uid] = [
             {
@@ -284,7 +372,10 @@ async def gemini_chatbot(client, ctx: Message, strings):
         ]
     else:
         gemini_conversations[uid].append({"role": "user", "content": user_content})
-    ai_response = await get_openai_stream_response(False, GOOGLEAI_KEY, "https://generativelanguage.googleapis.com/v1beta", "gemini-2.5-flash", gemini_conversations[uid], msg, strings)
+    ai_response = await get_openai_stream_response(
+        client, True, NINE_ROUTER_API_KEY, NINE_ROUTER_BASE_URL, model,
+        gemini_conversations[uid], msg, strings, ctx,
+    )
     if not ai_response:
         gemini_conversations[uid].pop()
         if len(gemini_conversations[uid]) == 1:
@@ -340,8 +431,8 @@ async def openai_chatbot(client, ctx: Message, strings):
             )
         user_content = ctx.input
 
-    if not OPENAI_KEY:
-        return await _reply_ctx(client, ctx, "OPENAI_KEY env is missing!!!")
+    if not NINE_ROUTER_API_KEY:
+        return await _reply_ctx(client, ctx, "NINE_ROUTER_API_KEY env is missing!!!")
 
     uid = (
         ctx.guest_bot_caller_user.id
@@ -354,7 +445,7 @@ async def openai_chatbot(client, ctx: Message, strings):
         return await _reply_ctx(client, ctx, strings("dont_spam"), del_in=5)
 
     pertanyaan = user_content
-    msg = await _progress_ctx(client, ctx, strings)
+    msg = None if _is_private_chat(ctx) else await _progress_ctx(client, ctx, strings)
     if uid not in gptai_conversations:
         gptai_conversations[uid] = [
             {
@@ -365,7 +456,10 @@ async def openai_chatbot(client, ctx: Message, strings):
         ]
     else:
         gptai_conversations[uid].append({"role": "user", "content": pertanyaan})
-    ai_response = await get_openai_stream_response(False, OPENAI_KEY, "https://openrouter.ai/api/v1", "deepseek/deepseek-r1-0528:free", gptai_conversations[uid], msg, strings)
+    ai_response = await get_openai_stream_response(
+        client, True, NINE_ROUTER_API_KEY, NINE_ROUTER_BASE_URL, NINE_ROUTER_MODEL_ASK,
+        gptai_conversations[uid], msg, strings, ctx,
+    )
     if not ai_response:
         gptai_conversations[uid].pop()
         if len(gptai_conversations[uid]) == 1:

--- a/misskaty/plugins/chatbot_ai.py
+++ b/misskaty/plugins/chatbot_ai.py
@@ -5,11 +5,13 @@
 import asyncio
 import html
 import re
+from logging import getLogger
 import privatebinapi
 
 from cachetools import TTLCache
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
 from pyrogram import enums, filters
+from pyrogram.errors import FloodWait, MessageNotModified
 from pyrogram.types import (
     InlineQueryResultArticle,
     InputRichMessage,
@@ -97,6 +99,38 @@ from misskaty.vars import (
     OWNER_ID,
     SUDO,
 )
+
+LOGGER = getLogger("MissKaty")
+
+
+async def _rich_send(client, chat_id, text: str, draft_id: int = None):
+    """Kirim rich message (draft/final) dengan handling FloodWait & error global.
+
+    - draft_id=None  -> send_rich_message (final)
+    - draft_id!=None -> send_rich_message_draft (streaming preview)
+    """
+    retries = 3
+    for attempt in range(retries):
+        try:
+            if draft_id is not None:
+                return await client.send_rich_message_draft(
+                    chat_id, draft_id, InputRichMessage(html=text)
+                )
+            return await client.send_rich_message(
+                chat_id, InputRichMessage(html=text)
+            )
+        except FloodWait as e:
+            LOGGER.warning(f"Got floodwait in {chat_id} for {e.value}'s.")
+            await asyncio.sleep(e.value)
+        except MessageNotModified:
+            return None
+        except Exception as e:
+            # Rich message masih eksperimental — jangan crash, log & lanjut
+            LOGGER.warning(f"send_rich_message error di {chat_id}: {e.__class__.__name__}: {e}")
+            if attempt == retries - 1:
+                return None
+            await asyncio.sleep(1)
+    return None
 
 
 def _extract_guest_prompt(ctx: Message) -> str:
@@ -217,7 +251,7 @@ def _is_private_chat(ctx: Message) -> bool:
 async def _deliver_error(client, ctx, bmsg, err: str, rich_mode: bool):
     """Kirim pesan error: rich message di private, edit_msg di tempat lain."""
     if rich_mode:
-        await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
+        await _rich_send(client, ctx.chat.id, err)
     else:
         await _edit_msg(bmsg, err)
 
@@ -230,7 +264,7 @@ async def _deliver_result(client, ctx, bmsg, text: str, strings, rich_mode: bool
     """
     if rich_mode:
         if not _rich_too_long(text):
-            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=text))
+            await _rich_send(client, ctx.chat.id, text)
             return
     else:
         if len(text) <= EDIT_MAX_CHARS:
@@ -246,7 +280,7 @@ async def _deliver_result(client, ctx, bmsg, text: str, strings, rich_mode: bool
         answerlink=answerlink.get("full_url")
     )
     if rich_mode:
-        await client.send_rich_message(ctx.chat.id, InputRichMessage(html=text))
+        await _rich_send(client, ctx.chat.id, text)
     else:
         await _edit_msg(bmsg, text, disable_web_page_preview=True)
 
@@ -267,11 +301,7 @@ async def get_openai_stream_response(
     draft_id = None
     if rich_mode:
         draft_id = client.rnd_id()
-        await client.send_rich_message_draft(
-            ctx.chat.id,
-            draft_id,
-            InputRichMessage(html=RICH_THINKING_HTML),
-        )
+        await _rich_send(client, ctx.chat.id, RICH_THINKING_HTML, draft_id)
     try:
         response = await ai.chat.completions.create(
             model=model,
@@ -294,11 +324,7 @@ async def get_openai_stream_response(
                     if _rich_too_long(answer):
                         continue
                     try:
-                        await client.send_rich_message_draft(
-                            ctx.chat.id,
-                            draft_id,
-                            InputRichMessage(html=html.escape(answer)),
-                        )
+                        await _rich_send(client, ctx.chat.id, html.escape(answer), draft_id)
                     except Exception:
                         pass
                 else:

--- a/misskaty/plugins/chatbot_ai.py
+++ b/misskaty/plugins/chatbot_ai.py
@@ -4,6 +4,7 @@
 # * Copyright ©YasirPedia All rights reserved
 import asyncio
 import html
+import re
 import privatebinapi
 
 from cachetools import TTLCache
@@ -167,6 +168,37 @@ gemini_conversations = TTLCache(maxsize=4000, ttl=24*60*60)
 
 RICH_THINKING_HTML = "<tg-thinking>🤔 <b>Mikir...</b></tg-thinking>"
 
+# Batasan rich message Telegram (Bot API):
+#   - 32768 UTF-8 chars (incl. emoji alt text & formula source)
+#   - 500 blocks (nested, list items, table rows, quotations, details)
+#   - 16 levels nested formatting/blocks
+#   - 50 media attachments
+#   - 20 table columns
+# Margin aman supaya tidak kena limit di tengah render.
+RICH_MAX_CHARS = 32000
+RICH_MAX_BLOCKS = 480
+# Telegram edit limit untuk fallback non-rich (edit_msg)
+EDIT_MAX_CHARS = 4000
+
+# Tag blok-level yang dihitung sebagai satu "block" oleh Telegram.
+# Hanya tag pembuka yang dihitung (</p> dst = penutup, bukan blok baru).
+_BLOCK_TAGS = re.compile(
+    r"<(?:p|div|li|tr|blockquote|details|summary|pre|h[1-6]|"
+    r"tg-heading|tg-subheading|tg-bold|tg-pre|tg-code|tg-blockquote|"
+    r"tg-slideshow|tg-collage|tg-map|tg-location|tg-math-block)\b",
+    re.IGNORECASE,
+)
+
+
+def _rich_too_long(text: str) -> bool:
+    """True jika teks melampaui batas rich message (chars atau blocks)."""
+    if len(text) > RICH_MAX_CHARS:
+        return True
+    # Estimasi jumlah blok dari tag blok-level (batas 500)
+    if len(_BLOCK_TAGS.findall(text)) > RICH_MAX_BLOCKS:
+        return True
+    return False
+
 
 def _is_private_chat(ctx: Message) -> bool:
     """True when we can use rich messages/drafts: private DM, not guest inline."""
@@ -184,17 +216,28 @@ async def _deliver_error(client, ctx, bmsg, err: str, rich_mode: bool):
 
 
 async def _deliver_result(client, ctx, bmsg, text: str, strings, rich_mode: bool):
-    """Kirim hasil: rich message di private, edit_msg di tempat lain."""
-    if len(text) > 4000:
-        answerlink = await privatebinapi.send_async(
-            "https://bin.yasirweb.eu.org",
-            text=text,
-            expiration="1week",
-            formatting="markdown",
-        )
-        text = strings("answers_too_long").format(
-            answerlink=answerlink.get("full_url")
-        )
+    """Kirim hasil: rich message di private, edit_msg di tempat lain.
+
+    Rich message punya batas 32768 char / 500 blok (Bot API); edit biasa
+    dibatasi 4096 char. Jika melampaui batas mode aktif -> privatebin.
+    """
+    if rich_mode:
+        if not _rich_too_long(text):
+            await client.send_rich_message(ctx.chat.id, InputRichMessage(html=text))
+            return
+    else:
+        if len(text) <= EDIT_MAX_CHARS:
+            await bmsg.edit_msg(text, disable_web_page_preview=True)
+            return
+    answerlink = await privatebinapi.send_async(
+        "https://bin.yasirweb.eu.org",
+        text=text,
+        expiration="1week",
+        formatting="markdown",
+    )
+    text = strings("answers_too_long").format(
+        answerlink=answerlink.get("full_url")
+    )
     if rich_mode:
         await client.send_rich_message(ctx.chat.id, InputRichMessage(html=text))
     else:
@@ -231,10 +274,7 @@ async def get_openai_stream_response(
         )
         if not is_stream:
             answer += response.choices[0].message.content or ""
-            if rich_mode:
-                await _edit_result(client, ctx, bmsg, f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>", strings)
-            else:
-                await _edit_result(client, ctx, bmsg, f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>", strings)
+            await _edit_result(client, ctx, bmsg, f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>", strings)
         else:
             async for chunk in response:
                 if not chunk.choices or not chunk.choices[0].delta.content:
@@ -242,7 +282,10 @@ async def get_openai_stream_response(
                 num += 1
                 answer += chunk.choices[0].delta.content
                 if rich_mode:
-                    # Streaming preview via rich draft (same draft_id = animated)
+                    # Streaming preview via rich draft (same draft_id = animated).
+                    # Skip update kalau sudah melampaui batas rich (hemat request).
+                    if _rich_too_long(answer):
+                        continue
                     try:
                         await client.send_rich_message_draft(
                             ctx.chat.id,

--- a/misskaty/plugins/chatbot_ai.py
+++ b/misskaty/plugins/chatbot_ai.py
@@ -58,7 +58,7 @@ async def _reply_ctx(client, ctx: Message, text: str, **kwargs):
         )
         return _GuestInlineMessage(client, sent.inline_message_id)
 
-    return await ctx.reply_msg(text, **kwargs)
+    return await ctx.reply(text, **kwargs)
 
 
 async def _progress_ctx(client, ctx: Message, strings):
@@ -76,7 +76,14 @@ async def _progress_ctx(client, ctx: Message, strings):
         )
         return _GuestInlineMessage(client, sent.inline_message_id)
 
-    return await ctx.reply_msg(strings("find_answers_str"), quote=True)
+    return await ctx.reply(strings("find_answers_str"), quote=True)
+
+
+async def _edit_msg(bmsg, text: str, **kwargs):
+    """Edit a message: Kurigram Message uses .edit(); guest adapter uses .edit_msg()."""
+    if hasattr(bmsg, "edit_msg"):
+        return await bmsg.edit_msg(text, **kwargs)
+    return await bmsg.edit(text, **kwargs)
 
 from misskaty import BOT_USERNAME, app
 from misskaty.core import pyro_cooldown
@@ -212,7 +219,7 @@ async def _deliver_error(client, ctx, bmsg, err: str, rich_mode: bool):
     if rich_mode:
         await client.send_rich_message(ctx.chat.id, InputRichMessage(html=err))
     else:
-        await bmsg.edit_msg(err)
+        await _edit_msg(bmsg, err)
 
 
 async def _deliver_result(client, ctx, bmsg, text: str, strings, rich_mode: bool):
@@ -227,7 +234,7 @@ async def _deliver_result(client, ctx, bmsg, text: str, strings, rich_mode: bool
             return
     else:
         if len(text) <= EDIT_MAX_CHARS:
-            await bmsg.edit_msg(text, disable_web_page_preview=True)
+            await _edit_msg(bmsg, text, disable_web_page_preview=True)
             return
     answerlink = await privatebinapi.send_async(
         "https://bin.yasirweb.eu.org",
@@ -241,7 +248,7 @@ async def _deliver_result(client, ctx, bmsg, text: str, strings, rich_mode: bool
     if rich_mode:
         await client.send_rich_message(ctx.chat.id, InputRichMessage(html=text))
     else:
-        await bmsg.edit_msg(text, disable_web_page_preview=True)
+        await _edit_msg(bmsg, text, disable_web_page_preview=True)
 
 
 async def _edit_result(client, ctx, bmsg, text: str, strings):
@@ -296,7 +303,7 @@ async def get_openai_stream_response(
                         pass
                 else:
                     if num == 30 and len(answer) < 4000:
-                        await bmsg.edit_msg(html.escape(answer))
+                        await _edit_msg(bmsg, html.escape(answer))
                         await asyncio.sleep(1.5)
                         num = 0
             final = f"{html.escape(answer)}\n\n<b>Powered by:</b> <code>{model}</code>"

--- a/misskaty/plugins/web_scraper.py
+++ b/misskaty/plugins/web_scraper.py
@@ -526,22 +526,20 @@ async def getDatalk21(msg, kueri, CurrentPage, strings):
         result = []
         try:
             with contextlib.redirect_stdout(sys.stderr):
-                try:
-                    if kueri:
-                        lk21json = await fetch.get(f"{web['yasirapi']}/lk21?q={kueri}")
-                    else:
-                        lk21json = await fetch.get(f"{web['yasirapi']}/lk21")
-                    lk21json.raise_for_status()
-                    result = lk21json.json().get("result") or []
-                except httpx.HTTPError:
-                    result = []
-        except Exception:
-            result = []
+                if kueri:
+                    lk21json = await fetch.get(f"{web['yasirapi']}/lk21?q={kueri}")
+                else:
+                    lk21json = await fetch.get(f"{web['yasirapi']}/lk21")
+                lk21json.raise_for_status()
+                result = lk21json.json().get("result") or []
+        except (httpx.HTTPError, ValueError) as exc:
+            # API error / response bukan JSON -> fallback scrape langsung
+            LOGGER.warning("LK21 API gagal (%s), fallback ke scrape langsung", exc)
         if not result:
-            # API kosong/error -> fallback scrape langsung dari situs
             try:
                 result = await _scrape_lk21_direct(kueri)
             except Exception as exc:
+                LOGGER.exception("LK21 direct scrape gagal")
                 await msg.edit(
                     f"ERROR: Gagal mengambil data LK21 - <code>{exc}</code>"
                 )
@@ -1246,22 +1244,22 @@ async def getSame(msg, query, current_page, strings):
 # Mapping: command -> (getdata_fn, page_prefix, needs_user)
 # ============================================================
 SCRAPER_REGISTRY = {
-    "samehadaku": ("getSame", "page_same", False),
-    "terbit21": ("getDataTerbit21", "page_terbit21", False),
-    "lk21": ("getDatalk21", "page_lk21", False),
-    "pahe": ("getDataPahe", "page_pahe", False),
-    "gomov": ("getDataGomov", "page_gomov", True),
-    "klikxxi": ("getDataGomov", "page_gomov", True),
-    "melongmovie": ("getDataMelong", "page_melong", True),
-    "nunadrama": ("getDataNunaDrama", "page_nuna", True),
-    "pusatfilm": ("getDataPusatFilm", "page_pf", True),
-    "dutamovie": ("getDataDutaMovie", "page_duta", True),
-    "savefilm21": ("getDataSavefilm21", "page_sf21", True),
-    "nodrakor": ("getDataNodrakor", "page_nodrakor", True),
-    "kusonime": ("getDataKuso", "page_kuso", True),
-    "lendrive": ("getDataLendrive", "page_lendrive", True),
-    "movieku": ("getDataMovieku", "page_movieku", True),
-    "oppaweb": ("getDataOppaweb", "page_oppaweb", True),
+    "samehadaku": (getSame, "page_same", False),
+    "terbit21": (getDataTerbit21, "page_terbit21", False),
+    "lk21": (getDatalk21, "page_lk21", False),
+    "pahe": (getDataPahe, "page_pahe", False),
+    "gomov": (getDataGomov, "page_gomov", True),
+    "klikxxi": (getDataGomov, "page_gomov", True),
+    "melongmovie": (getDataMelong, "page_melong", True),
+    "nunadrama": (getDataNunaDrama, "page_nuna", True),
+    "pusatfilm": (getDataPusatFilm, "page_pf", True),
+    "dutamovie": (getDataDutaMovie, "page_duta", True),
+    "savefilm21": (getDataSavefilm21, "page_sf21", True),
+    "nodrakor": (getDataNodrakor, "page_nodrakor", True),
+    "kusonime": (getDataKuso, "page_kuso", True),
+    "lendrive": (getDataLendrive, "page_lendrive", True),
+    "movieku": (getDataMovieku, "page_movieku", True),
+    "oppaweb": (getDataOppaweb, "page_oppaweb", True),
 }
 
 PAGE_REGISTRY = {v[1]: (v[0], v[2]) for v in SCRAPER_REGISTRY.values()}
@@ -1271,8 +1269,7 @@ PAGE_REGISTRY = {v[1]: (v[0], v[2]) for v in SCRAPER_REGISTRY.values()}
 @use_chat_lang()
 async def scraper_cmd(_, message, strings):
     cmd = message.command[0].lower().lstrip("/")
-    fn_name, page_prefix, needs_user = SCRAPER_REGISTRY[cmd]
-    func = globals()[fn_name]
+    func, page_prefix, needs_user = SCRAPER_REGISTRY[cmd]
     kueri = " ".join(message.command[1:]) or None
     pesan = await message.reply(strings("get_data"))
     if needs_user:
@@ -1315,10 +1312,9 @@ async def scraper_page_callback(_, callback_query, strings):
         return
 
     prefix = callback_query.data.split("#")[0]
-    fn_name, needs_user = PAGE_REGISTRY.get(prefix, (None, False))
-    if not fn_name:
+    func, needs_user = PAGE_REGISTRY.get(prefix, (None, False))
+    if not func:
         return
-    func = globals()[fn_name]
     try:
         if needs_user:
             res, PageLen, btn = await func(

--- a/misskaty/plugins/web_scraper.py
+++ b/misskaty/plugins/web_scraper.py
@@ -1241,402 +1241,66 @@ async def getSame(msg, query, current_page, strings):
     return sameresult, PageLen
 
 
-# SameHada CMD
-@app.on_cmd("samehadaku", no_channel=True)
-@use_chat_lang()
-async def same_search(_, msg, strings):
-    query = msg.text.split(maxsplit=1)[1] if len(msg.command) > 1 else None
-    bmsg = await msg.reply(strings("get_data"))
-    sameres, PageLen = await getSame(bmsg, query, 1, strings)
-    if not sameres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen, 1, "page_same#{number}" + f"#{bmsg.id}#{msg.from_user.id}"
-    )
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{msg.from_user.id}"))
-    await bmsg.edit(sameres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard)
+# ============================================================
+# GENERIC SCRAPER HANDLERS (command + page callback)
+# Mapping: command -> (getdata_fn, page_prefix, needs_user)
+# ============================================================
+SCRAPER_REGISTRY = {
+    "samehadaku": ("getSame", "page_same", False),
+    "terbit21": ("getDataTerbit21", "page_terbit21", False),
+    "lk21": ("getDatalk21", "page_lk21", False),
+    "pahe": ("getDataPahe", "page_pahe", False),
+    "gomov": ("getDataGomov", "page_gomov", True),
+    "klikxxi": ("getDataGomov", "page_gomov", True),
+    "melongmovie": ("getDataMelong", "page_melong", True),
+    "nunadrama": ("getDataNunaDrama", "page_nuna", True),
+    "pusatfilm": ("getDataPusatFilm", "page_pf", True),
+    "dutamovie": ("getDataDutaMovie", "page_duta", True),
+    "savefilm21": ("getDataSavefilm21", "page_sf21", True),
+    "nodrakor": ("getDataNodrakor", "page_nodrakor", True),
+    "kusonime": ("getDataKuso", "page_kuso", True),
+    "lendrive": ("getDataLendrive", "page_lendrive", True),
+    "movieku": ("getDataMovieku", "page_movieku", True),
+    "oppaweb": ("getDataOppaweb", "page_oppaweb", True),
+}
+
+PAGE_REGISTRY = {v[1]: (v[0], v[2]) for v in SCRAPER_REGISTRY.values()}
 
 
-# Terbit21 CMD
-@app.on_cmd("terbit21", no_channel=True)
+@app.on_cmd(list(SCRAPER_REGISTRY.keys()), no_channel=True)
 @use_chat_lang()
-async def terbit21_s(_, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = None
+async def scraper_cmd(_, message, strings):
+    cmd = message.command[0].lower().lstrip("/")
+    fn_name, page_prefix, needs_user = SCRAPER_REGISTRY[cmd]
+    func = globals()[fn_name]
+    kueri = " ".join(message.command[1:]) or None
     pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    terbitres, PageLen = await getDataTerbit21(pesan, kueri, CurrentPage, strings)
-    if not terbitres:
+    if needs_user:
+        res, PageLen, btn = await func(pesan, kueri, 1, message.from_user.id, strings)
+    else:
+        res, PageLen = await func(pesan, kueri, 1, strings)
+    if not res:
         return
     keyboard = InlineKeyboard()
     keyboard.paginate(
         PageLen,
-        CurrentPage,
-        "page_terbit21#{number}" + f"#{pesan.id}#{message.from_user.id}",
+        1,
+        f"{page_prefix}#{{number}}" + f"#{pesan.id}#{message.from_user.id}",
     )
+    if needs_user:
+        keyboard.row(InlineButton(strings("ex_data"), user_id=_.me.id))
+        keyboard.row(*btn)
     keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
     await pesan.edit(
-        terbitres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# LK21 CMD
-@app.on_cmd("lk21", no_channel=True)
-@use_chat_lang()
-async def lk21_s(_, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = None
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    lkres, PageLen = await getDatalk21(pesan, kueri, CurrentPage, strings)
-    if not lkres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_lk21#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(lkres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard)
-
-
-# Pahe CMD
-@app.on_cmd("pahe", no_channel=True)
-@use_chat_lang()
-async def pahe_s(_, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    paheres, PageLen = await getDataPahe(pesan, kueri, CurrentPage, strings)
-    if not paheres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_pahe#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(paheres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard)
-
-
-# Gomov CMD
-@app.on_cmd(["gomov", "klikxxi"], no_channel=True)
-@use_chat_lang()
-async def gomov_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    gomovres, PageLen, btn = await getDataGomov(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not gomovres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_gomov#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(gomovres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard)
-
-
-# MelongMovie CMD
-@app.on_cmd("melongmovie", no_channel=True)
-@use_chat_lang()
-async def melong_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    melongres, PageLen, btn = await getDataMelong(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not melongres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_melong#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    try:
-        await pesan.edit(
-            melongres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-        )
-    except Exception as err:
-        await pesan.edit(
-            f"<b>ERROR:</b> {err}", link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-        )
-
-
-# NunaDrama CMD
-@app.on_cmd("nunadrama", no_channel=True)
-@use_chat_lang()
-async def nunadrama_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    nunares, PageLen, btn = await getDataNunaDrama(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not nunares:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_nuna#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(
-        nunares, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# PusatFilm21 CMD
-@app.on_cmd("pusatfilm", no_channel=True)
-@use_chat_lang()
-async def pusatfilm_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    pfres, PageLen, btn = await getDataPusatFilm(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not pfres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_pf#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(
-        pfres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# DutaMovie CMD
-@app.on_cmd("dutamovie", no_channel=True)
-@use_chat_lang()
-async def dutamovie_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    dutares, PageLen, btn = await getDataDutaMovie(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not dutares:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_nuna#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(
-        dutares, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Savefilm21 CMD
-@app.on_cmd("savefilm21", no_channel=True)
-@use_chat_lang()
-async def savefilm_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    savefilmres, PageLen, btn = await getDataSavefilm21(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not savefilmres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_sf21#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(
-        savefilmres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# NoDrakor CMD
-@app.on_cmd("nodrakor", no_channel=True)
-@use_chat_lang()
-async def nodrakor_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    nodrakorres, PageLen, btn = await getDataNodrakor(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not nodrakorres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_nodrakor#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(
-        nodrakorres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Kusonime CMD
-@app.on_cmd("kusonime", no_channel=True)
-@use_chat_lang()
-async def kusonime_s(self, message, strings):
-    kueri = " ".join(message.command[1:])
-    if not kueri:
-        kueri = ""
-    pesan = await message.reply(strings("get_data"))
-    CurrentPage = 1
-    kusores, PageLen, btn1, btn2 = await getDataKuso(
-        pesan, kueri, CurrentPage, message.from_user.id, strings
-    )
-    if not kusores:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_kuso#{number}" + f"#{pesan.id}#{message.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn1)
-    if btn2:
-        keyboard.row(*btn2)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{message.from_user.id}"))
-    await pesan.edit(kusores, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard)
-
-
-# Lendrive CMD
-@app.on_cmd("lendrive", no_channel=True)
-@use_chat_lang()
-async def lendrive_s(self, ctx: Message, strings):
-    kueri = ctx.input
-    if not kueri:
-        kueri = ""
-    pesan = await ctx.reply(strings("get_data"))
-    CurrentPage = 1
-    lendres, PageLen, btn = await getDataLendrive(
-        pesan, kueri, CurrentPage, ctx.from_user.id, strings
-    )
-    if not lendres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_lendrive#{number}" + f"#{pesan.id}#{ctx.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{ctx.from_user.id}"))
-    await pesan.edit(lendres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard)
-
-
-# Movieku CMD
-@app.on_cmd("movieku", no_channel=True)
-@use_chat_lang()
-async def movieku_s(self, ctx: Message, strings):
-    kueri = ctx.input
-    if not kueri:
-        kueri = ""
-    pesan = await ctx.reply(strings("get_data"))
-    CurrentPage = 1
-    moviekures, PageLen, btn = await getDataMovieku(pesan, kueri, CurrentPage, ctx.from_user.id, strings)
-    if not moviekures:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_movieku#{number}" + f"#{pesan.id}#{ctx.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{ctx.from_user.id}"))
-    await pesan.edit(
-        moviekures, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# OppaWeb CMD
-@app.on_cmd("oppaweb", no_channel=True)
-@use_chat_lang()
-async def oppaweb_s(self, ctx: Message, strings):
-    kueri = ctx.input or ""
-    pesan = await ctx.reply(strings("get_data"))
-    CurrentPage = 1
-    oppawebres, PageLen, btn = await getDataOppaweb(
-        pesan, kueri, CurrentPage, ctx.from_user.id, strings
-    )
-    if not oppawebres:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_oppaweb#{number}" + f"#{pesan.id}#{ctx.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{ctx.from_user.id}"))
-    await pesan.edit(
-        oppawebres,
+        res,
         link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
         reply_markup=keyboard,
     )
 
 
-# OppaWeb Page Callback
-@app.on_cb("page_oppaweb#")
+@app.on_cb("page_")
 @use_chat_lang()
-async def oppawebpage_callback(self, callback_query, strings):
+async def scraper_page_callback(_, callback_query, strings):
     try:
         if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
             return await callback_query.answer(strings("unauth"), True)
@@ -1650,14 +1314,18 @@ async def oppawebpage_callback(self, callback_query, strings):
     except QueryIdInvalid:
         return
 
+    prefix = callback_query.data.split("#")[0]
+    fn_name, needs_user = PAGE_REGISTRY.get(prefix, (None, False))
+    if not fn_name:
+        return
+    func = globals()[fn_name]
     try:
-        oppawebres, PageLen, btn = await getDataOppaweb(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
+        if needs_user:
+            res, PageLen, btn = await func(
+                callback_query.message, kueri, CurrentPage, callback_query.from_user.id, strings
+            )
+        else:
+            res, PageLen = await func(callback_query.message, kueri, CurrentPage, strings)
     except TypeError:
         return
 
@@ -1665,611 +1333,74 @@ async def oppawebpage_callback(self, callback_query, strings):
     keyboard.paginate(
         PageLen,
         CurrentPage,
-        "page_oppaweb#{number}" + f"#{message_id}#{callback_query.from_user.id}",
+        f"{prefix}#{{number}}" + f"#{message_id}#{callback_query.from_user.id}",
     )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
+    if needs_user:
+        keyboard.row(InlineButton(strings("ex_data"), user_id=_.me.id))
+        keyboard.row(*btn)
     keyboard.row(
         InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
     )
     await callback_query.message.edit(
-        oppawebres,
+        res,
         link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
         reply_markup=keyboard,
     )
 
 
-# Savefillm21 Page Callback
-@app.on_cb("page_sf21#")
-@use_chat_lang()
-async def sf21page_callback(self, callback_query, strings):
+# ============================================================
+# GENERIC EXTRACT HANDLER (semua *extract# callback)
+# Dispatch ke fungsi per-situs; parsing + keyboard terpusat
+# ============================================================
+async def _extract_cb_parse(callback_query, strings, back_prefix, store):
+    """Parse callback data + buat keyboard back/close. Return (link, keyboard) atau None."""
     try:
         if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except (IndexError, ValueError):  # Gatau napa err ini
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-    except QueryIdInvalid:
-        return
-
-    try:
-        savefilmres, PageLen, btn = await getDataSavefilm21(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_sf21#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        savefilmres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# NunaDrama Page Callback
-@app.on_cb("page_nuna#")
-@use_chat_lang()
-async def nunapage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except (IndexError, ValueError):  # Gatau napa err ini
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-    except QueryIdInvalid:
-        return
-
-    try:
-        nunares, PageLen, btn = await getDataNunaDrama(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_nuna#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        nunares, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# DutaMovie Page Callback
-@app.on_cb("page_duta#")
-@use_chat_lang()
-async def dutapage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except (IndexError, ValueError):
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-    except QueryIdInvalid:
-        return
-
-    try:
-        dutares, PageLen, btn = await getDataDutaMovie(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_duta#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        dutares, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-# PusatFilm Page Callback
-@app.on_cb("page_pf#")
-@use_chat_lang()
-async def pfpage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except (IndexError, ValueError):
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-    except QueryIdInvalid:
-        return
-
-    try:
-        pfres, PageLen, btn = await getDataDutaMovie(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_pf#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        pfres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# NoDrakor Page Callback
-@app.on_cb("page_nodrakor#")
-@use_chat_lang()
-async def nodrakorpage_cb(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except (IndexError, ValueError):
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-    except QueryIdInvalid:
-        return
-
-    try:
-        nodrakorres, PageLen, btn = await getDataNodrakor(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_nodrakor#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        nodrakorres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Kuso Page Callback
-@app.on_cb("page_kuso#")
-@use_chat_lang()
-async def kusopage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    try:
-        kusores, PageLen, btn1, btn2 = await getDataKuso(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_kuso#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn1)
-    if btn2:
-        keyboard.row(*btn2)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        kusores, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Lendrive Page Callback
-@app.on_cb("page_lendrive#")
-@use_chat_lang()
-async def lendrivepage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = savedict[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    try:
-        lendres, PageLen, btn = await getDataLendrive(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_lendrive#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        lendres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Movieku Page Callback
-@app.on_cb("page_movieku#")
-@use_chat_lang()
-async def moviekupage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"), True)
-
-    try:
-        moviekures, PageLen, btn = await getDataMovieku(
-            callback_query.message, kueri, CurrentPage, callback_query.from_user.id, strings
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_movieku#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        moviekures, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Samehada Page Callback
-@app.on_cb("page_same#")
-@use_chat_lang()
-async def samepg(_, query, strings):
-    try:
-        _, current_page, _id, user_id = query.data.split("#")
-        if int(user_id) != query.from_user.id:
-            return await query.answer(strings("unauth"), True)
-        lquery = savedict[int(_id)][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await query.message.edit(strings("invalid_cb"))
-    try:
-        sameres, PageLen = await getSame(
-            query.message, lquery, int(current_page), strings
-        )
-    except TypeError:
-        return
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        int(current_page),
-        "page_same#{number}" + f"#{_id}#{query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("cl_btn"), f"close#{query.from_user.id}"))
-    await query.message.edit(
-        sameres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Terbit21 Page Callback
-@app.on_cb("page_terbit21#")
-@use_chat_lang()
-async def terbit21page_callback(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    try:
-        terbitres, PageLen = await getDataTerbit21(
-            callback_query.message, kueri, CurrentPage, strings
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_terbit21#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        terbitres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Page Callback Melong
-@app.on_cb("page_melong#")
-@use_chat_lang()
-async def melongpage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    try:
-        terbitres, PageLen, btn = await getDataMelong(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_melong#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        terbitres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Lk21 Page Callback
-@app.on_cb("page_lk21#")
-@use_chat_lang()
-async def lk21page_callback(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    try:
-        lkres, PageLen = await getDatalk21(
-            callback_query.message, kueri, CurrentPage, strings
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_lk21#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        lkres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Pahe Page Callback
-@app.on_cb("page_pahe#")
-@use_chat_lang()
-async def pahepage_callback(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    try:
-        lkres, PageLen = await getDataPahe(
-            callback_query.message, kueri, CurrentPage, strings
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_pahe#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        lkres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-# Gomov Page Callback
-@app.on_cb("page_gomov#")
-@use_chat_lang()
-async def gomovpage_callback(self, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        message_id = int(callback_query.data.split("#")[2])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        kueri = SCRAP_DICT[message_id][1]
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    try:
-        gomovres, PageLen, btn = await getDataGomov(
-            callback_query.message,
-            kueri,
-            CurrentPage,
-            callback_query.from_user.id,
-            strings,
-        )
-    except TypeError:
-        return
-
-    keyboard = InlineKeyboard()
-    keyboard.paginate(
-        PageLen,
-        CurrentPage,
-        "page_gomov#{number}" + f"#{message_id}#{callback_query.from_user.id}",
-    )
-    keyboard.row(InlineButton(strings("ex_data"), user_id=self.me.id))
-    keyboard.row(*btn)
-    keyboard.row(
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}")
-    )
-    await callback_query.message.edit(
-        gomovres, link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True), reply_markup=keyboard
-    )
-
-
-### Scrape DDL Link From Web ###
-# OppaWeb DDL
-@app.on_cb("oppawebextract#")
-@use_chat_lang()
-async def oppaweb_scrap(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
+            await callback_query.answer(strings("unauth"), True)
+            return None
         idlink = int(callback_query.data.split("#")[2])
         message_id = int(callback_query.data.split("#")[4])
         CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
+        link = store[message_id][0][CurrentPage - 1][idlink - 1].get("link")
+    except (IndexError, ValueError):
+        return None
     except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
+        await callback_query.message.edit(strings("invalid_cb"))
+        return None
+    except QueryIdInvalid:
+        return None
 
     keyboard = InlineKeyboard()
     keyboard.row(
         InlineButton(
             strings("back_btn"),
-            f"page_oppaweb#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
+            f"{back_prefix}#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
         ),
         InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
     )
+    return link, keyboard
+
+
+@app.on_cb(r"\w+extract#")
+@use_chat_lang()
+async def scraper_extract_cb(client, callback_query, strings):
+    prefix = callback_query.data.split("#")[0]
+    entry = EXTRACT_REGISTRY.get(prefix)
+    if not entry:
+        return
+    back_prefix, handler = entry
+    store = savedict if prefix == "lendriveextract" else SCRAP_DICT
+    parsed = await _extract_cb_parse(callback_query, strings, back_prefix, store)
+    if not parsed:
+        return
+    link, keyboard = parsed
+    await handler(client, callback_query, strings, link, keyboard)
+
+
+# ============================================================
+# LOGIKA EXTRACT PER SITUS (bukan handler, dipanggil via registry)
+# ============================================================
+async def _extract_oppaweb(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(
@@ -2312,31 +1443,8 @@ async def oppaweb_scrap(_, callback_query, strings):
             await callback_query.message.edit(f"ERROR: {err}", reply_markup=keyboard)
 
 
-# Kusonime DDL
-@app.on_cb("kusoextract#")
-@use_chat_lang()
-async def kusonime_scrap(client, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
+async def _extract_kuso(client, callback_query, strings, link, keyboard):
     kuso = Kusonime()
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_kuso#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
     try:
         if init_url := data_kuso.get(link, False):
             await callback_query.message.edit(
@@ -2351,30 +1459,7 @@ async def kusonime_scrap(client, callback_query, strings):
             return await callback_query.message.edit(e, reply_markup=keyboard)
 
 
-# Savefilm21 DDL
-@app.on_cb("sf21extract#")
-@use_chat_lang()
-async def savefilm21_scrap(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_sf21#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_savefilm21(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2396,30 +1481,7 @@ async def savefilm21_scrap(_, callback_query, strings):
             )
 
 
-# NunaDrama DDL
-@app.on_cb("nunaextract#")
-@use_chat_lang()
-async def nunadrama_ddl(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_sf21#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_nuna(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2446,30 +1508,7 @@ async def nunadrama_ddl(_, callback_query, strings):
             )
 
 
-# PusatFilm21 DDL
-@app.on_cb("pfextract#")
-@use_chat_lang()
-async def pusatfilm_ddl(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_pf#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_pusatfilm(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2491,30 +1530,7 @@ async def pusatfilm_ddl(_, callback_query, strings):
             )
 
 
-# DutaMovie DDL
-@app.on_cb("dutaextract#")
-@use_chat_lang()
-async def dutamovie_ddl(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_duta#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_duta(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2541,30 +1557,7 @@ async def dutamovie_ddl(_, callback_query, strings):
             )
 
 
-# NoDrakor DDL
-@app.on_cb("nodrakorextract#")
-@use_chat_lang()
-async def nodrakorddl_scrap(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_nodrakor#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_nodrakor(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2602,30 +1595,7 @@ async def nodrakorddl_scrap(_, callback_query, strings):
             )
 
 
-# Scrape DDL Link Melongmovie
-@app.on_cb("moviekuextract#")
-@use_chat_lang()
-async def movieku_scrap(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_movieku#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_movieku(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2673,30 +1643,7 @@ async def movieku_scrap(_, callback_query, strings):
             )
 
 
-# Scrape DDL Link Melongmovie
-@app.on_cb("melongextract#")
-@use_chat_lang()
-async def melong_scrap(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_melong#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_melong(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2721,30 +1668,7 @@ async def melong_scrap(_, callback_query, strings):
             )
 
 
-# Scrape DDL Link Gomov
-@app.on_cb("gomovextract#")
-@use_chat_lang()
-async def gomov_dl(_, callback_query, strings):
-    try:
-        if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-            return await callback_query.answer(strings("unauth"), True)
-        idlink = int(callback_query.data.split("#")[2])
-        message_id = int(callback_query.data.split("#")[4])
-        CurrentPage = int(callback_query.data.split("#")[1])
-        link = SCRAP_DICT[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except QueryIdInvalid:
-        return
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_gomov#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_gomov(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             html = await fetch.get(link)
@@ -2770,27 +1694,7 @@ async def gomov_dl(_, callback_query, strings):
             )
 
 
-@app.on_cb("lendriveextract#")
-@use_chat_lang()
-async def lendrive_dl(_, callback_query, strings):
-    if callback_query.from_user.id != int(callback_query.data.split("#")[3]):
-        return await callback_query.answer(strings("unauth"), True)
-    idlink = int(callback_query.data.split("#")[2])
-    message_id = int(callback_query.data.split("#")[4])
-    CurrentPage = int(callback_query.data.split("#")[1])
-    try:
-        link = savedict[message_id][0][CurrentPage - 1][idlink - 1].get("link")
-    except KeyError:
-        return await callback_query.message.edit(strings("invalid_cb"))
-
-    keyboard = InlineKeyboard()
-    keyboard.row(
-        InlineButton(
-            strings("back_btn"),
-            f"page_lendrive#{CurrentPage}#{message_id}#{callback_query.from_user.id}",
-        ),
-        InlineButton(strings("cl_btn"), f"close#{callback_query.from_user.id}"),
-    )
+async def _extract_lendrive(client, callback_query, strings, link, keyboard):
     with contextlib.redirect_stdout(sys.stderr):
         try:
             hmm = await fetch.get(link)
@@ -2818,6 +1722,22 @@ async def lendrive_dl(_, callback_query, strings):
             await callback_query.message.edit(
                 f"ERROR: {err}", reply_markup=keyboard
             )
+
+
+EXTRACT_REGISTRY = {
+    "oppawebextract": ("page_oppaweb", _extract_oppaweb),
+    "kusoextract": ("page_kuso", _extract_kuso),
+    "sf21extract": ("page_sf21", _extract_savefilm21),
+    "nunaextract": ("page_nuna", _extract_nuna),
+    "pfextract": ("page_pf", _extract_pusatfilm),
+    "dutaextract": ("page_duta", _extract_duta),
+    "nodrakorextract": ("page_nodrakor", _extract_nodrakor),
+    "moviekuextract": ("page_movieku", _extract_movieku),
+    "melongextract": ("page_melong", _extract_melong),
+    "gomovextract": ("page_gomov", _extract_gomov),
+    "lendriveextract": ("page_lendrive", _extract_lendrive),
+}
+
 
 # Manual Scrape DDL Movieku.CC incase cannot auto scrape from button
 @app.on_cmd("movieku_scrap")

--- a/misskaty/vars.py
+++ b/misskaty/vars.py
@@ -66,6 +66,11 @@ SUPPORT_CHAT = environ.get("SUPPORT_CHAT", "YasirPediaChannel")
 AUTO_RESTART = environ.get("AUTO_RESTART", False)
 OPENAI_KEY = environ.get("OPENAI_KEY")
 GOOGLEAI_KEY = environ.get("GOOGLEAI_KEY")
+# 9Router (OpenAI-compatible gateway) untuk chatbot AI
+NINE_ROUTER_API_KEY = environ.get("NINE_ROUTER_API_KEY")
+NINE_ROUTER_BASE_URL = environ.get("NINE_ROUTER_BASE_URL", "https://9router.yasirweb.eu.org/v1")
+NINE_ROUTER_MODEL_AI = environ.get("NINE_ROUTER_MODEL_AI", "oc/mimo-v2.5-free")
+NINE_ROUTER_MODEL_ASK = environ.get("NINE_ROUTER_MODEL_ASK", "oc/deepseek-v4-flash-free")
 PAYDISINI_KEY = environ.get("PAYDISINI_KEY")
 PAYDISINI_CHANNEL_ID = environ.get("PAYDISINI_CHANNEL_ID", "17")
 


### PR DESCRIPTION
## Ringkasan
Refactor plugin `chatbot_ai` agar memakai gateway **9Router** (OpenAI-compatible) + support rich message.

## Perubahan
| Area | Detail |
|------|--------|
| Provider | `https://9router.yasirweb.eu.org/v1` (env `NINE_ROUTER_BASE_URL`) |
| `/ai` | **mimo** (`oc/mimo-v2.5-free`) |
| `/ask` & guest mode | **deepseek** (`oc/deepseek-v4-flash-free`) |
| Private chat | **Rich messages**: streaming draft dengan placeholder `<tg-thinking>` (efek thinking) + final `send_rich_message` |
| Grup / guest inline | Fallback **edit biasa** (`edit_msg` / `edit_inline_text`, Kurigram) |
| API key | `NINE_ROUTER_API_KEY` env (repo publik, key TIDAK di-hardcode) |

## Cara kerja rich message (private chat)
1. `send_rich_message_draft(chat_id, draft_id, <tg-thinking>...)` — placeholder berpikir
2. Stream chunk → update draft yang sama (`draft_id` sama = animasi mengetik)
3. `send_rich_message(chat_id, InputRichMessage(html=final))` — hasil final

Di grup/guest: reply "Mencari jawaban..." lalu `edit_msg` biasa.

## Setup
```bash
NINE_ROUTER_API_KEY=sk-xxx   # wajib, tidak ikut ke repo
NINE_ROUTER_BASE_URL=https://9router.yasirweb.eu.org/v1  # optional (default)
```

## Verifikasi
- `py_compile` ✅ (chatbot_ai.py + vars.py)
- Tes dispatch (stub): `/ai` DM → mimo + rich path (bmsg None); `/ai` grup → bmsg ada (edit fallback); guest & `/ask` → deepseek ✅
- Tes rich stream: thinking draft → stream → rich final ✅
- Referensi Gemini/OpenRouter lama hilang ✅

## Summary by Sourcery

Switch chatbot AI to 9Router with rich private replies, and refactor scraper handlers and extract callbacks into generic, registry-driven logic with improved LK21 API fallback.

New Features:
- Support rich message drafts and final rich responses for AI replies in private chats.
- Configure chatbot AI provider via 9Router env variables, including separate models for /ai and /ask.

Bug Fixes:
- Improve LK21 API error handling by logging failures and reliably falling back to direct scraping when the API or JSON parsing fails.

Enhancements:
- Refactor multiple site-specific scraper commands and pagination callbacks into generic, registry-based handlers to reduce duplication and centralize behavior.
- Unify DDL extract callbacks behind a single dispatcher and per-site handler functions with shared parsing and keyboard construction.
- Update chatbot help text and routing so /ai uses the Mimo model and /ask and guest mode use DeepSeek via 9Router.