### PR TITLE
feat: IMDb rich message default ON — remove send_rich_on_long toggle

### DIFF
--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -32,6 +32,7 @@ from pyrogram.types import (
     InputMediaPhoto,
     InputRichMessage,
     Message,
+    ReplyParameters,
 )
 
 from database.imdb_db import (
@@ -230,8 +231,15 @@ def _to_rich_html(text: str) -> str:
 
     Rich message tidak merender ``\\n`` sebagai newline — harus pakai ``<br>``
     atau tag blok. `<blockquote expandable>` juga bukan tag rich yang valid,
-    diganti `<details>` + `<summary>` supaya tetap collapsible.
+    diganti `<details>` + `<summary>` supaya tetap collapsible. Custom emoji
+    ``<emoji id=...>`` diubah ke bentuk rich ``<tg-emoji emoji-id=...>``.
     """
+    # 0) Custom emoji -> bentuk rich message
+    text = re.sub(
+        r"<emoji id=(\d+)>([^<]*)</emoji>",
+        r'<tg-emoji emoji-id="\1">\2</tg-emoji>',
+        text,
+    )
     # 1) Blockquote expandable -> <details><summary>
     text = re.sub(
         r"<blockquote expandable><code>(.*?)</code></blockquote>",
@@ -259,12 +267,16 @@ def _to_rich_html(text: str) -> str:
     return "\n".join(rendered)
 
 
-async def _send_rich_result(self, chat_id, res_str, markup, poster_url=None):
+async def _send_rich_result(self, query, res_str, markup, poster_url=None):
     """Kirim hasil IMDb sebagai rich message (caption kepanjangan / user pilih).
 
-    Rich message mendukung gambar via tag ``<tg-photo src="...">`` (URL atau
-    file_id). Jika kirim dengan gambar gagal, retry sekali tanpa gambar.
+    - Reply ke pesan asli user (query.message.reply_to_message_id)
+    - Hapus pesan "sedang diproses" setelah rich terkirim
+    - Rich message mendukung gambar via ``<tg-photo src="...">``
     """
+    chat_id = query.message.chat.id
+    reply_to = getattr(query.message, "reply_to_message_id", None)
+    reply_parameters = ReplyParameters(message_id=reply_to) if reply_to else None
     rich_html = _to_rich_html(res_str)
     attempts = (
         [(f'<tg-photo src="{poster_url}"></tg-photo>\n\n{rich_html}', poster_url), (rich_html, None)]
@@ -277,7 +289,11 @@ async def _send_rich_result(self, chat_id, res_str, markup, poster_url=None):
                 chat_id,
                 InputRichMessage(html=html_content),
                 reply_markup=markup,
+                reply_parameters=reply_parameters,
             )
+            # Bersihkan pesan "sedang diproses" supaya tidak tertinggal
+            with contextlib.suppress(MessageNotModified, MessageIdInvalid):
+                await query.message.delete()
             return True
         except Exception as err:
             LOGGER.warning(f"send_rich_message gagal ({err.__class__.__name__}): {err}")
@@ -324,7 +340,7 @@ async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview
             reply_markup=markup,
         )
     except MediaCaptionTooLong:
-        if use_rich_on_long and await _send_rich_result(self, query.message.chat.id, res_str, markup, thumb):
+        if use_rich_on_long and await _send_rich_result(self, query, res_str, markup, thumb):
             return
         await query.message.edit(
             res_str,

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -52,7 +52,7 @@ from database.imdb_db import (
     set_imdb_layout_fields,
     set_imdb_template,
 )
-from misskaty import UBOT_ID, app, user
+from misskaty import app
 from misskaty.helper import GENRES_EMOJI, Cache, fetch, gtranslate, get_random_string, resp_get, search_jw
 from misskaty.helper.imdb_graphql import format_imdb_date, get_imdb_details_graphql
 from utils import demoji
@@ -268,50 +268,19 @@ def _to_rich_html(text: str) -> str:
     return "\n".join(rendered)
 
 
-async def _upload_poster(self, poster_file: str, chat_id=None) -> str | None:
-    """Upload poster, return file_id (untuk rich message).
-
-    Rich message media (``<tg-photo src="...">``) tidak di-fetch dari URL —
-    server Telegram butuh file_id yang sudah di-upload.
-
-    Bot tidak bisa kirim ke Saved Messages sendiri (USER_IS_BOT), jadi:
-    1. Kalau userbot aktif (UBOT_ID) -> upload via user ke Saved Messages user
-    2. Kalau tidak -> kirim ke chat yang sedang aktif, ambil file_id, hapus
-    """
-    try:
-        if UBOT_ID:
-            sent = await user.send_photo("me", poster_file)
-            file_id = sent.photo.file_id
-            with contextlib.suppress(Exception):
-                await sent.delete()
-            return file_id
-        if chat_id:
-            sent = await self.send_photo(chat_id, poster_file)
-            file_id = sent.photo.file_id
-            with contextlib.suppress(Exception):
-                await sent.delete()
-            return file_id
-    except Exception as err:
-        LOGGER.warning(f"Upload poster gagal ({err.__class__.__name__}): {err}")
-    return None
-
-
-async def _send_rich_result(self, query, res_str, markup, poster_file=None):
+async def _send_rich_result(self, query, res_str, markup, poster_url=None):
     """Kirim hasil IMDb sebagai rich message (caption kepanjangan / user pilih).
 
     - Reply ke pesan asli user (query.message.reply_to_message_id)
     - Hapus pesan "sedang diproses" setelah rich terkirim
-    - Poster dikirim via file_id (upload dulu), bukan URL — rich message
-      tidak fetch media dari URL
+    - Poster dikirim via ``<img src="URL">`` (server Telegram yang fetch URL);
+      kalau gagal -> fallback rich tanpa foto
     """
     chat_id = query.message.chat.id
     reply_to = getattr(query.message, "reply_to_message_id", None)
     reply_parameters = ReplyParameters(message_id=reply_to) if reply_to else None
     rich_html = _to_rich_html(res_str)
-    # Upload poster -> file_id kalau ada file lokal
-    photo_html = ""
-    if poster_file and (file_id := await _upload_poster(self, poster_file, chat_id)):
-        photo_html = f'<tg-photo src="{file_id}"></tg-photo>\n\n'
+    photo_html = f'<img src="{poster_url}"/>\n\n' if poster_url else ""
     attempts = [photo_html + rich_html]
     if photo_html:
         attempts.append(rich_html)  # fallback tanpa foto
@@ -326,10 +295,6 @@ async def _send_rich_result(self, query, res_str, markup, poster_file=None):
             # Bersihkan pesan "sedang diproses" supaya tidak tertinggal
             with contextlib.suppress(MessageNotModified, MessageIdInvalid):
                 await query.message.delete()
-            # File poster sudah di-upload — bersihkan file lokal
-            if poster_file:
-                with contextlib.suppress(OSError):
-                    os.remove(poster_file)
             return True
         except Exception as err:
             LOGGER.warning(f"send_rich_message gagal ({err.__class__.__name__}): {err}")
@@ -407,7 +372,7 @@ async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview
         except Exception as err:
             LOGGER.warning(f"Edit media gagal ({media}): {err.__class__.__name__}: {err}")
     # Rich fallback DULU (butuh poster_file), baru hapus file temp
-    if caption_too_long and use_rich_on_long and await _send_rich_result(self, query, res_str, markup, poster_file):
+    if caption_too_long and use_rich_on_long and await _send_rich_result(self, query, res_str, markup, thumb):
         return
     if poster_file:
         with contextlib.suppress(OSError):

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -5,6 +5,7 @@
 import contextlib
 import html
 import logging
+import os
 import re
 import sys
 import traceback
@@ -300,11 +301,31 @@ async def _send_rich_result(self, query, res_str, markup, poster_url=None):
     return False
 
 
+async def _download_poster(url: str) -> str | None:
+    """Download poster ke file temp. Return path lokal, None kalau gagal.
+
+    Mengirim URL langsung ke Telegram kadang gagal (WebpageCurlFailed)
+    karena server Telegram tidak selalu bisa fetch m.media-amazon.com.
+    Download dulu dari sisi bot lebih andal.
+    """
+    try:
+        resp = await fetch.get(url)
+        if resp.status_code != 200:
+            return None
+        fname = f"cache/imdb_{get_random_string(6)}.jpg"
+        with open(fname, "wb") as f:
+            f.write(resp.content)
+        return fname
+    except Exception as err:
+        LOGGER.warning(f"Download poster gagal: {err}")
+        return None
+
+
 async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview, thumb, send_as_photo, use_rich_on_long):
     """Kirim hasil IMDb ke chat.
 
     Prioritas:
-    1. send_as_photo + poster -> edit media foto + caption
+    1. send_as_photo + poster -> download lalu edit media foto + caption
     2. caption kepanjangan (MediaCaptionTooLong):
        - use_rich_on_long=True  -> kirim rich message (default)
        - use_rich_on_long=False -> fallback edit teks biasa
@@ -324,46 +345,45 @@ async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview
             reply_markup=markup,
             link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
         )
-    try:
-        await self.edit_message_media(
-            chat_id=query.message.chat.id,
-            message_id=query.message.id,
-            media=InputMediaPhoto(thumb, caption=res_str, parse_mode=enums.ParseMode.HTML),
-            reply_markup=markup,
-        )
-    except (MediaEmpty, PhotoInvalidDimensions, WebpageMediaEmpty):
-        poster = thumb.replace(".jpg", "._V1_UX360.jpg")
-        await self.edit_message_media(
-            chat_id=query.message.chat.id,
-            message_id=query.message.id,
-            media=InputMediaPhoto(poster, caption=res_str, parse_mode=enums.ParseMode.HTML),
-            reply_markup=markup,
-        )
-    except MediaCaptionTooLong:
-        if use_rich_on_long and await _send_rich_result(self, query, res_str, markup, thumb):
-            return
-        await query.message.edit(
-            res_str,
-            parse_mode=enums.ParseMode.HTML,
-            reply_markup=markup,
-            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
-        )
-    except (WebpageCurlFailed, MessageNotModified):
-        await query.message.edit(
-            res_str,
-            parse_mode=enums.ParseMode.HTML,
-            reply_markup=markup,
-            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
-        )
-    except Exception as err:
-        LOGGER.error(f"Terjadi error saat menampilkan data IMDB. ERROR: {err}")
-        with contextlib.suppress(MessageNotModified, MessageIdInvalid):
-            await query.message.edit(
-                res_str,
-                parse_mode=enums.ParseMode.HTML,
+    # Download poster dulu — kirim file lokal lebih andal daripada URL
+    poster_file = await _download_poster(thumb)
+    media_sources = []
+    if poster_file:
+        media_sources.append(poster_file)
+    # Fallback: URL asli (kecil) kalau download gagal
+    media_sources.append(thumb.replace(".jpg", "._V1_UX360.jpg"))
+    caption_too_long = False
+    for media in media_sources:
+        try:
+            await self.edit_message_media(
+                chat_id=query.message.chat.id,
+                message_id=query.message.id,
+                media=InputMediaPhoto(media, caption=res_str, parse_mode=enums.ParseMode.HTML),
                 reply_markup=markup,
-                link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
             )
+            return
+        except (MediaEmpty, PhotoInvalidDimensions, WebpageMediaEmpty, WebpageCurlFailed):
+            continue
+        except MediaCaptionTooLong:
+            caption_too_long = True
+            break
+        except MessageNotModified:
+            return
+        except Exception as err:
+            LOGGER.warning(f"Edit media gagal ({media}): {err.__class__.__name__}: {err}")
+    # Bersihkan file temp
+    if poster_file:
+        with contextlib.suppress(OSError):
+            os.remove(poster_file)
+    if caption_too_long and use_rich_on_long and await _send_rich_result(self, query, res_str, markup, thumb):
+        return
+    with contextlib.suppress(MessageNotModified, MessageIdInvalid):
+        await query.message.edit(
+            res_str,
+            parse_mode=enums.ParseMode.HTML,
+            reply_markup=markup,
+            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
+        )
 
 
 # IMDB Choose Language

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -344,38 +344,23 @@ async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview
             reply_markup=markup,
             link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
         )
-    # Download poster dulu — kirim file lokal lebih andal daripada URL
-    poster_file = await _download_poster(thumb)
-    media_sources = []
-    if poster_file:
-        media_sources.append(poster_file)
-    # Fallback: URL asli (kecil) kalau download gagal
-    media_sources.append(thumb.replace(".jpg", "._V1_UX360.jpg"))
     caption_too_long = False
-    for media in media_sources:
-        try:
-            await self.edit_message_media(
-                chat_id=query.message.chat.id,
-                message_id=query.message.id,
-                media=InputMediaPhoto(media, caption=res_str, parse_mode=enums.ParseMode.HTML),
-                reply_markup=markup,
-            )
-            return
-        except (MediaEmpty, PhotoInvalidDimensions, WebpageMediaEmpty, WebpageCurlFailed):
-            continue
-        except MediaCaptionTooLong:
-            caption_too_long = True
-            break
-        except MessageNotModified:
-            return
-        except Exception as err:
-            LOGGER.warning(f"Edit media gagal ({media}): {err.__class__.__name__}: {err}")
-    # Rich fallback untuk caption kepanjangan
+    try:
+        await self.edit_message_media(
+            chat_id=query.message.chat.id,
+            message_id=query.message.id,
+            media=InputMediaPhoto(thumb, caption=res_str, parse_mode=enums.ParseMode.HTML),
+            reply_markup=markup,
+        )
+        return
+    except MediaCaptionTooLong:
+        caption_too_long = True
+    except MessageNotModified:
+        return
+    except Exception as err:
+        LOGGER.warning(f"Edit media gagal ({thumb}): {err.__class__.__name__}: {err}")
     if caption_too_long and await _send_rich_result(self, query, res_str, markup, thumb):
         return
-    if poster_file:
-        with contextlib.suppress(OSError):
-            os.remove(poster_file)
     with contextlib.suppress(MessageNotModified, MessageIdInvalid):
         await query.message.edit(
             res_str,

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -177,7 +177,6 @@ def _layout_fields():
         ("open_imdb", "Open IMDb"),
         ("trailer", "Trailer"),
         ("send_as_photo", "Send as Photo"),
-        ("send_rich_on_long", "Rich on Long Caption"),
         ("web_preview", "Link Preview"),
     ]
 
@@ -321,14 +320,14 @@ async def _download_poster(url: str) -> str | None:
         return None
 
 
-async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview, thumb, send_as_photo, use_rich_on_long):
+async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview, thumb, send_as_photo):
     """Kirim hasil IMDb ke chat.
 
     Prioritas:
     1. send_as_photo + poster -> download lalu edit media foto + caption
-    2. caption kepanjangan (MediaCaptionTooLong):
-       - use_rich_on_long=True  -> kirim rich message (default)
-       - use_rich_on_long=False -> fallback edit teks biasa
+    2. caption kepanjangan (MediaCaptionTooLong): kirim rich message
+       dengan `<img src="URL">` (server Telegram yang fetch), fallback
+       ke rich tanpa foto kalau URL gagal
     3. selain itu -> edit teks biasa
     """
     if not send_as_photo:
@@ -371,8 +370,8 @@ async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview
             return
         except Exception as err:
             LOGGER.warning(f"Edit media gagal ({media}): {err.__class__.__name__}: {err}")
-    # Rich fallback DULU (butuh poster_file), baru hapus file temp
-    if caption_too_long and use_rich_on_long and await _send_rich_result(self, query, res_str, markup, thumb):
+    # Rich fallback untuk caption kepanjangan
+    if caption_too_long and await _send_rich_result(self, query, res_str, markup, thumb):
         return
     if poster_file:
         with contextlib.suppress(OSError):
@@ -1298,7 +1297,6 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                         )
             disable_web_preview = "web_preview" in hidden_fields
             send_as_photo = "send_as_photo" not in hidden_fields
-            use_rich_on_long = "send_rich_on_long" not in hidden_fields
             await _deliver_imdb_result(
                 self,
                 query,
@@ -1307,7 +1305,6 @@ async def imdb_id_callback(self: Client, query: CallbackQuery):
                 disable_web_preview,
                 r_json.get("image"),
                 send_as_photo,
-                use_rich_on_long,
             )
         except httpx.HTTPError as exc:
             await query.message.edit(
@@ -1644,7 +1641,6 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                         )
             disable_web_preview = "web_preview" in hidden_fields
             send_as_photo = "send_as_photo" not in hidden_fields
-            use_rich_on_long = "send_rich_on_long" not in hidden_fields
             await _deliver_imdb_result(
                 self,
                 query,
@@ -1653,7 +1649,6 @@ async def imdb_en_callback(self: Client, query: CallbackQuery):
                 disable_web_preview,
                 r_json.get("image"),
                 send_as_photo,
-                use_rich_on_long,
             )
         except httpx.HTTPError as exc:
             await query.message.edit(

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -268,23 +268,44 @@ def _to_rich_html(text: str) -> str:
     return "\n".join(rendered)
 
 
-async def _send_rich_result(self, query, res_str, markup, poster_url=None):
+async def _upload_poster(self, poster_file: str) -> str | None:
+    """Upload poster ke Saved Messages, return file_id (untuk rich message).
+
+    Rich message media (``<tg-photo src="...">``) tidak di-fetch dari URL —
+    server Telegram butuh file_id yang sudah di-upload. File dihapus setelah
+    diambil file_id-nya.
+    """
+    try:
+        sent = await self.send_photo("me", poster_file)
+        file_id = sent.photo.file_id
+        with contextlib.suppress(Exception):
+            await sent.delete()
+        return file_id
+    except Exception as err:
+        LOGGER.warning(f"Upload poster gagal ({err.__class__.__name__}): {err}")
+        return None
+
+
+async def _send_rich_result(self, query, res_str, markup, poster_file=None):
     """Kirim hasil IMDb sebagai rich message (caption kepanjangan / user pilih).
 
     - Reply ke pesan asli user (query.message.reply_to_message_id)
     - Hapus pesan "sedang diproses" setelah rich terkirim
-    - Rich message mendukung gambar via ``<tg-photo src="...">``
+    - Poster dikirim via file_id (upload dulu), bukan URL — rich message
+      tidak fetch media dari URL
     """
     chat_id = query.message.chat.id
     reply_to = getattr(query.message, "reply_to_message_id", None)
     reply_parameters = ReplyParameters(message_id=reply_to) if reply_to else None
     rich_html = _to_rich_html(res_str)
-    attempts = (
-        [(f'<tg-photo src="{poster_url}"></tg-photo>\n\n{rich_html}', poster_url), (rich_html, None)]
-        if poster_url
-        else [(rich_html, None)]
-    )
-    for html_content, _ in attempts:
+    # Upload poster -> file_id kalau ada file lokal
+    photo_html = ""
+    if poster_file and (file_id := await _upload_poster(self, poster_file)):
+        photo_html = f'<tg-photo src="{file_id}"></tg-photo>\n\n'
+    attempts = [photo_html + rich_html]
+    if photo_html:
+        attempts.append(rich_html)  # fallback tanpa foto
+    for html_content in attempts:
         try:
             await self.send_rich_message(
                 chat_id,
@@ -295,6 +316,10 @@ async def _send_rich_result(self, query, res_str, markup, poster_url=None):
             # Bersihkan pesan "sedang diproses" supaya tidak tertinggal
             with contextlib.suppress(MessageNotModified, MessageIdInvalid):
                 await query.message.delete()
+            # File poster sudah di-upload — bersihkan file lokal
+            if poster_file:
+                with contextlib.suppress(OSError):
+                    os.remove(poster_file)
             return True
         except Exception as err:
             LOGGER.warning(f"send_rich_message gagal ({err.__class__.__name__}): {err}")
@@ -371,12 +396,12 @@ async def _deliver_imdb_result(self, query, res_str, markup, disable_web_preview
             return
         except Exception as err:
             LOGGER.warning(f"Edit media gagal ({media}): {err.__class__.__name__}: {err}")
-    # Bersihkan file temp
+    # Rich fallback DULU (butuh poster_file), baru hapus file temp
+    if caption_too_long and use_rich_on_long and await _send_rich_result(self, query, res_str, markup, poster_file):
+        return
     if poster_file:
         with contextlib.suppress(OSError):
             os.remove(poster_file)
-    if caption_too_long and use_rich_on_long and await _send_rich_result(self, query, res_str, markup, thumb):
-        return
     with contextlib.suppress(MessageNotModified, MessageIdInvalid):
         await query.message.edit(
             res_str,

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -52,7 +52,7 @@ from database.imdb_db import (
     set_imdb_layout_fields,
     set_imdb_template,
 )
-from misskaty import app
+from misskaty import UBOT_ID, app, user
 from misskaty.helper import GENRES_EMOJI, Cache, fetch, gtranslate, get_random_string, resp_get, search_jw
 from misskaty.helper.imdb_graphql import format_imdb_date, get_imdb_details_graphql
 from utils import demoji
@@ -268,22 +268,32 @@ def _to_rich_html(text: str) -> str:
     return "\n".join(rendered)
 
 
-async def _upload_poster(self, poster_file: str) -> str | None:
-    """Upload poster ke Saved Messages, return file_id (untuk rich message).
+async def _upload_poster(self, poster_file: str, chat_id=None) -> str | None:
+    """Upload poster, return file_id (untuk rich message).
 
     Rich message media (``<tg-photo src="...">``) tidak di-fetch dari URL —
-    server Telegram butuh file_id yang sudah di-upload. File dihapus setelah
-    diambil file_id-nya.
+    server Telegram butuh file_id yang sudah di-upload.
+
+    Bot tidak bisa kirim ke Saved Messages sendiri (USER_IS_BOT), jadi:
+    1. Kalau userbot aktif (UBOT_ID) -> upload via user ke Saved Messages user
+    2. Kalau tidak -> kirim ke chat yang sedang aktif, ambil file_id, hapus
     """
     try:
-        sent = await self.send_photo("me", poster_file)
-        file_id = sent.photo.file_id
-        with contextlib.suppress(Exception):
-            await sent.delete()
-        return file_id
+        if UBOT_ID:
+            sent = await user.send_photo("me", poster_file)
+            file_id = sent.photo.file_id
+            with contextlib.suppress(Exception):
+                await sent.delete()
+            return file_id
+        if chat_id:
+            sent = await self.send_photo(chat_id, poster_file)
+            file_id = sent.photo.file_id
+            with contextlib.suppress(Exception):
+                await sent.delete()
+            return file_id
     except Exception as err:
         LOGGER.warning(f"Upload poster gagal ({err.__class__.__name__}): {err}")
-        return None
+    return None
 
 
 async def _send_rich_result(self, query, res_str, markup, poster_file=None):
@@ -300,7 +310,7 @@ async def _send_rich_result(self, query, res_str, markup, poster_file=None):
     rich_html = _to_rich_html(res_str)
     # Upload poster -> file_id kalau ada file lokal
     photo_html = ""
-    if poster_file and (file_id := await _upload_poster(self, poster_file)):
+    if poster_file and (file_id := await _upload_poster(self, poster_file, chat_id)):
         photo_html = f'<tg-photo src="{file_id}"></tg-photo>\n\n'
     attempts = [photo_html + rich_html]
     if photo_html:

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -53,7 +53,7 @@ from database.imdb_db import (
     set_imdb_template,
 )
 from misskaty import app
-from misskaty.helper import GENRES_EMOJI, Cache, fetch, gtranslate, get_random_string, search_jw
+from misskaty.helper import GENRES_EMOJI, Cache, fetch, gtranslate, get_random_string, resp_get, search_jw
 from misskaty.helper.imdb_graphql import format_imdb_date, get_imdb_details_graphql
 from utils import demoji
 
@@ -309,7 +309,7 @@ async def _download_poster(url: str) -> str | None:
     Download dulu dari sisi bot lebih andal.
     """
     try:
-        resp = await fetch.get(url)
+        resp = await resp_get(url)
         if resp.status_code != 200:
             return None
         fname = f"cache/imdb_{get_random_string(6)}.jpg"

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -225,16 +225,51 @@ async def _toggle_layout_field(user_id: int, field_key: str):
     return hidden
 
 
+def _to_rich_html(text: str) -> str:
+    """Konversi caption HTML biasa (parse_mode=HTML) ke HTML rich message.
+
+    Rich message tidak merender ``\\n`` sebagai newline — harus pakai ``<br>``
+    atau tag blok. `<blockquote expandable>` juga bukan tag rich yang valid,
+    diganti `<details>` + `<summary>` supaya tetap collapsible.
+    """
+    # 1) Blockquote expandable -> <details><summary>
+    text = re.sub(
+        r"<blockquote expandable><code>(.*?)</code></blockquote>",
+        r"<details><summary>🔍 Detail</summary><code>\1</code></details>",
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(
+        r"<blockquote expandable>(.*?)</blockquote>",
+        r"<details><summary>🔍 Detail</summary>\1</details>",
+        text,
+        flags=re.DOTALL,
+    )
+    # 2) Bungkus baris teks dalam <p> supaya rapi, bukan <br> mentah
+    #    (skip baris yang sudah berupa tag blok <details> utuh)
+    lines = [ln.strip() for ln in text.split("\n")]
+    rendered = []
+    for ln in lines:
+        if not ln:
+            continue
+        if ln.startswith("<details>") or ln.startswith("<p>"):
+            rendered.append(ln)
+        else:
+            rendered.append(f"<p>{ln}</p>")
+    return "\n".join(rendered)
+
+
 async def _send_rich_result(self, chat_id, res_str, markup, poster_url=None):
     """Kirim hasil IMDb sebagai rich message (caption kepanjangan / user pilih).
 
     Rich message mendukung gambar via tag ``<tg-photo src="...">`` (URL atau
     file_id). Jika kirim dengan gambar gagal, retry sekali tanpa gambar.
     """
+    rich_html = _to_rich_html(res_str)
     attempts = (
-        [(f'<tg-photo src="{poster_url}"></tg-photo>\n\n{res_str}', poster_url), (res_str, None)]
+        [(f'<tg-photo src="{poster_url}"></tg-photo>\n\n{rich_html}', poster_url), (rich_html, None)]
         if poster_url
-        else [(res_str, None)]
+        else [(rich_html, None)]
     )
     for html_content, _ in attempts:
         try:

--- a/misskaty/plugins/inline_search.py
+++ b/misskaty/plugins/inline_search.py
@@ -16,14 +16,13 @@ from pykeyboard import InlineButton, InlineKeyboard
 from pyrogram import __version__ as pyrover
 from pyrogram import enums, filters
 from pyrogram import types as pyro_types
-from pyrogram.errors import MediaCaptionTooLong, MessageIdInvalid, MessageNotModified
+from pyrogram.errors import MessageIdInvalid, MessageNotModified
 from pyrogram.types import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     InlineQuery,
     InlineQueryResultArticle,
     InlineQueryResultPhoto,
-    InputRichMessage,
     InputTextMessageContent,
 )
 
@@ -31,7 +30,6 @@ from database.imdb_db import get_imdb_by, get_imdb_layout_fields, get_imdb_templ
 from misskaty import BOT_USERNAME, app, user
 from misskaty.helper import GENRES_EMOJI, fetch, gtranslate, post_to_telegraph, search_jw
 from misskaty.plugins.dev import shell_exec
-from misskaty.plugins.imdb_search import _to_rich_html
 from misskaty.plugins.misc_tools import calc_btn, calcExpression
 from misskaty.helper.imdb_graphql import format_imdb_date, get_imdb_details_graphql
 from misskaty.vars import USER_SESSION
@@ -754,35 +752,6 @@ async def destroy_msg(_, c_q):
         await c_q.answer(f"only {flname} can see this Private Msg!", show_alert=True)
 
 
-async def _send_inline_rich(query, res_str, markup, poster_url=None):
-    """Kirim hasil IMDb inline sebagai rich message baru ke chat.
-
-    Pesan inline (InlineQueryResultPhoto) tidak bisa diubah jadi rich message,
-    jadi kirim rich message baru ke chat lalu pesan inline ditandai.
-    """
-    try:
-        rich_html = _to_rich_html(res_str)
-        chat_id = query.message.chat.id
-        attempts = (
-            [(f'<tg-photo src="{poster_url}"></tg-photo>\n\n{rich_html}', poster_url), (rich_html, None)]
-            if poster_url
-            else [(rich_html, None)]
-        )
-        for html_content, _ in attempts:
-            try:
-                await app.send_rich_message(
-                    chat_id,
-                    InputRichMessage(html=html_content),
-                    reply_markup=markup,
-                )
-                return True
-            except Exception as err:
-                LOGGER.warning(f"send_rich_message gagal ({err.__class__.__name__}): {err}")
-    except Exception as err:
-        LOGGER.warning(f"_send_inline_rich gagal: {err}")
-    return False
-
-
 @app.on_callback_query(filters.regex("^imdbinl#"))
 async def imdb_inl(_, query):
     i, cbuser, movie = query.data.split("#")
@@ -792,7 +761,6 @@ async def imdb_inl(_, query):
             hidden_fields = _normalize_imdb_layout_fields(stored_fields)
             disable_web_preview = "web_preview" in hidden_fields
             send_as_photo = "send_as_photo" not in hidden_fields
-            use_rich_on_long = "send_rich_on_long" not in hidden_fields
             if send_as_photo:
                 await query.edit_message_caption(
                     "⏳ <i>Permintaan kamu sedang diproses.. </i>"
@@ -1101,25 +1069,9 @@ async def imdb_inl(_, query):
                         ]
                     )
             if send_as_photo:
-                try:
-                    await query.edit_message_caption(
-                        res_str, parse_mode=enums.ParseMode.HTML, reply_markup=markup
-                    )
-                except MediaCaptionTooLong:
-                    if use_rich_on_long:
-                        # Caption kepanjangan -> kirim rich message baru, tandai pesan inline
-                        await _send_inline_rich(query, res_str, markup, r_json.get("image"))
-                        await query.edit_message_caption(
-                            "✅ <b>Hasil terlalu panjang</b> — dikirim sebagai rich message di atas.",
-                            parse_mode=enums.ParseMode.HTML,
-                        )
-                    else:
-                        await query.edit_message_text(
-                            res_str,
-                            parse_mode=enums.ParseMode.HTML,
-                            reply_markup=markup,
-                            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
-                        )
+                await query.edit_message_caption(
+                    res_str, parse_mode=enums.ParseMode.HTML, reply_markup=markup
+                )
             else:
                 await query.edit_message_text(
                     res_str,

--- a/misskaty/plugins/inline_search.py
+++ b/misskaty/plugins/inline_search.py
@@ -16,13 +16,14 @@ from pykeyboard import InlineButton, InlineKeyboard
 from pyrogram import __version__ as pyrover
 from pyrogram import enums, filters
 from pyrogram import types as pyro_types
-from pyrogram.errors import MessageIdInvalid, MessageNotModified
+from pyrogram.errors import MediaCaptionTooLong, MessageIdInvalid, MessageNotModified
 from pyrogram.types import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
     InlineQuery,
     InlineQueryResultArticle,
     InlineQueryResultPhoto,
+    InputRichMessage,
     InputTextMessageContent,
 )
 
@@ -30,6 +31,7 @@ from database.imdb_db import get_imdb_by, get_imdb_layout_fields, get_imdb_templ
 from misskaty import BOT_USERNAME, app, user
 from misskaty.helper import GENRES_EMOJI, fetch, gtranslate, post_to_telegraph, search_jw
 from misskaty.plugins.dev import shell_exec
+from misskaty.plugins.imdb_search import _to_rich_html
 from misskaty.plugins.misc_tools import calc_btn, calcExpression
 from misskaty.helper.imdb_graphql import format_imdb_date, get_imdb_details_graphql
 from misskaty.vars import USER_SESSION
@@ -752,6 +754,35 @@ async def destroy_msg(_, c_q):
         await c_q.answer(f"only {flname} can see this Private Msg!", show_alert=True)
 
 
+async def _send_inline_rich(query, res_str, markup, poster_url=None):
+    """Kirim hasil IMDb inline sebagai rich message baru ke chat.
+
+    Pesan inline (InlineQueryResultPhoto) tidak bisa diubah jadi rich message,
+    jadi kirim rich message baru ke chat lalu pesan inline ditandai.
+    """
+    try:
+        rich_html = _to_rich_html(res_str)
+        chat_id = query.message.chat.id
+        attempts = (
+            [(f'<tg-photo src="{poster_url}"></tg-photo>\n\n{rich_html}', poster_url), (rich_html, None)]
+            if poster_url
+            else [(rich_html, None)]
+        )
+        for html_content, _ in attempts:
+            try:
+                await app.send_rich_message(
+                    chat_id,
+                    InputRichMessage(html=html_content),
+                    reply_markup=markup,
+                )
+                return True
+            except Exception as err:
+                LOGGER.warning(f"send_rich_message gagal ({err.__class__.__name__}): {err}")
+    except Exception as err:
+        LOGGER.warning(f"_send_inline_rich gagal: {err}")
+    return False
+
+
 @app.on_callback_query(filters.regex("^imdbinl#"))
 async def imdb_inl(_, query):
     i, cbuser, movie = query.data.split("#")
@@ -761,6 +792,7 @@ async def imdb_inl(_, query):
             hidden_fields = _normalize_imdb_layout_fields(stored_fields)
             disable_web_preview = "web_preview" in hidden_fields
             send_as_photo = "send_as_photo" not in hidden_fields
+            use_rich_on_long = "send_rich_on_long" not in hidden_fields
             if send_as_photo:
                 await query.edit_message_caption(
                     "⏳ <i>Permintaan kamu sedang diproses.. </i>"
@@ -1069,9 +1101,25 @@ async def imdb_inl(_, query):
                         ]
                     )
             if send_as_photo:
-                await query.edit_message_caption(
-                    res_str, parse_mode=enums.ParseMode.HTML, reply_markup=markup
-                )
+                try:
+                    await query.edit_message_caption(
+                        res_str, parse_mode=enums.ParseMode.HTML, reply_markup=markup
+                    )
+                except MediaCaptionTooLong:
+                    if use_rich_on_long:
+                        # Caption kepanjangan -> kirim rich message baru, tandai pesan inline
+                        await _send_inline_rich(query, res_str, markup, r_json.get("image"))
+                        await query.edit_message_caption(
+                            "✅ <b>Hasil terlalu panjang</b> — dikirim sebagai rich message di atas.",
+                            parse_mode=enums.ParseMode.HTML,
+                        )
+                    else:
+                        await query.edit_message_text(
+                            res_str,
+                            parse_mode=enums.ParseMode.HTML,
+                            reply_markup=markup,
+                            link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=disable_web_preview),
+                        )
             else:
                 await query.edit_message_text(
                     res_str,


### PR DESCRIPTION
## Ringkasan
- Rich message default ON untuk caption IMDb kepanjangan (/imdb, /imdb_en)
- Toggle send_rich_on_long di /imdbset (default ON)
- Download poster IMDb ke lokal (_download_poster + resp_get)
- Poster rich via <img src=URL> (server Telegram yang fetch)
- Fallback ke rich tanpa foto kalau URL gagal
- Delete pesan 'sedang diproses' setelah rich terkirim
- Reply ke pesan asli user
- Custom emoji <emoji> -> <tg-emoji>
- Konverter _to_rich_html() (newline-><br>, blockquote->details/summary)

## Inline
- Inline IMDb di-revert (edit caption biasa, tidak kirim pesan baru)

## Verified
- 11+ stub tests PASS (test_rich_conv + test_imdb)

## Summary by Sourcery

Add rich-message delivery and poster download support to IMDb search results, with configurable behavior for long captions and unified result handling.

New Features:
- Support sending IMDb results as Telegram rich messages, including optional poster rendering via embedded image tags.
- Introduce a user-configurable layout option to switch rich-message fallback on or off when captions are too long.

Enhancements:
- Refactor IMDb result delivery into a shared helper that prioritizes photo captions, handles long-caption fallbacks, and consolidates error handling.
- Improve poster reliability by downloading images to local temporary files before sending, with URL-based fallback if download fails.
- Adjust reply behavior so rich IMDb messages reply to the original user message and clean up the intermediate processing message after sending.