### PR TITLE
fix(mediainfo, filters, imdb): moov fallback, protect_content, close btn layout

### DIFF
--- a/misskaty/plugins/filters.py
+++ b/misskaty/plugins/filters.py
@@ -256,18 +256,18 @@ async def filters_re(self, message):
                 if not file_id:
                     continue
             if data_type == "sticker":
+                # reply_sticker TIDAK punya param protect_content di pyrogram 2.x
                 await message.reply_sticker(
                     sticker=file_id,
                     disable_notification=send_opts["disable_notification"],
-                    protect_content=send_opts["protect_content"],
                 )
             if data_type == "animation":
+                # reply_animation TIDAK punya param protect_content di pyrogram 2.x
                 await message.reply_animation(
                     animation=file_id,
                     caption=data,
                     reply_markup=keyb,
                     disable_notification=send_opts["disable_notification"],
-                    protect_content=send_opts["protect_content"],
                     has_spoiler=send_opts["media_spoiler"],
                 )
             if data_type == "photo":
@@ -288,12 +288,12 @@ async def filters_re(self, message):
                     protect_content=send_opts["protect_content"],
                 )
             if data_type == "video":
+                # reply_video TIDAK punya param protect_content di pyrogram 2.x
                 await message.reply_video(
                     video=file_id,
                     caption=data,
                     reply_markup=keyb,
                     disable_notification=send_opts["disable_notification"],
-                    protect_content=send_opts["protect_content"],
                     has_spoiler=send_opts["media_spoiler"],
                 )
             if data_type == "video_note":
@@ -303,20 +303,20 @@ async def filters_re(self, message):
                     protect_content=send_opts["protect_content"],
                 )
             if data_type == "audio":
+                # reply_audio TIDAK punya param protect_content di pyrogram 2.x
                 await message.reply_audio(
                     audio=file_id,
                     caption=data,
                     reply_markup=keyb,
                     disable_notification=send_opts["disable_notification"],
-                    protect_content=send_opts["protect_content"],
                 )
             if data_type == "voice":
+                # reply_voice TIDAK punya param protect_content di pyrogram 2.x
                 await message.reply_voice(
                     voice=file_id,
                     caption=data,
                     reply_markup=keyb,
                     disable_notification=send_opts["disable_notification"],
-                    protect_content=send_opts["protect_content"],
                 )
             return
 

--- a/misskaty/plugins/imdb_search.py
+++ b/misskaty/plugins/imdb_search.py
@@ -1414,8 +1414,10 @@ async def _build_imdb_result(
                     res_str = res_str.replace(lines.get(line_key, ""), "")
 
     # ---- tombol ----
+    # Tombol Close custom emoji: label tanpa emoji teks (icon custom emoji
+    # sudah menampilkan ❌ — label ber-emoji teks jadi dobel).
     close_btn = InlineKeyboardButton(
-        "❌ Close",
+        "Close",
         callback_data=f"close#{uid}",
         icon_custom_emoji_id=IMDB_CUSTOM_EMOJI["close"],
         style=enums.ButtonStyle.DANGER,
@@ -1434,11 +1436,10 @@ async def _build_imdb_result(
                 buttons.append(InlineKeyboardButton("🎬 Open IMDB", url=imdb_url))
             if "trailer" not in hidden_fields:
                 buttons.append(InlineKeyboardButton("▶️ Trailer", url=trailer_url))
-            if buttons:
-                buttons.append(close_btn)
-                markup = InlineKeyboardMarkup([buttons])
-            else:
-                markup = InlineKeyboardMarkup([[close_btn]])
+            rows = [buttons] if buttons else []
+            # Close SELALU di baris sendiri di bawah (tidak berjejer)
+            rows.append([close_btn])
+            markup = InlineKeyboardMarkup(rows)
         else:
             if "open_imdb" in hidden_fields:
                 markup = InlineKeyboardMarkup([[close_btn]])

--- a/misskaty/plugins/mediainfo.py
+++ b/misskaty/plugins/mediainfo.py
@@ -321,17 +321,27 @@ def _has_moov_atom(file_path: str, scan_mb: int = 20) -> bool:
         return False
 
 
-async def _mediainfo_timeout(cmd: str, timeout: int = 20) -> tuple[str, str, int]:
-    """Jalankan command dengan timeout; kill process tree kalau hang.
+async def _mediainfo_timeout(cmd_args: list[str], timeout: int = 20) -> tuple[str, str, int]:
+    """Jalankan command (list args) dengan timeout; kill process tree kalau hang.
 
-    PENTING: setelah ``proc.kill()`` pakai ``proc.wait()`` BUKAN
-    ``communicate()`` — communicate membaca pipe yang masih dipegang child
-    process yang sudah di-kill -> hang selamanya (zombie). Ini pelajaran
-    CrossXBot commit e461cd0f.
+    Pakai ``asyncio.create_subprocess_exec`` (bukan shell string) supaya path
+    dengan karakter aneh tidak bisa pecah/inject. ``start_new_session=True``
+    menjadikan proses sebagai leader process group sendiri, sehingga pada
+    timeout kita bisa ``os.killpg`` — membunuh seluruh child process, bukan
+    cuma proses utama (pelajaran CrossXBot commit e461cd0f + review Sourcery).
+
+    Returns:
+        ``(stdout, stderr, returncode)``
     """
+    import os
+    import signal
+
     try:
-        proc = await asyncio.create_subprocess_shell(
-            cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        proc = await asyncio.create_subprocess_exec(
+            *cmd_args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
         )
         try:
             stdout, stderr = await asyncio.wait_for(
@@ -343,9 +353,12 @@ async def _mediainfo_timeout(cmd: str, timeout: int = 20) -> tuple[str, str, int
                 proc.returncode or 0,
             )
         except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()  # bukan communicate() — hindari zombie pipe
-            LOGGER.warning("mediainfo timeout setelah %ss: %s", timeout, cmd[:120])
+            # Kill SELURUH process group (bukan cuma main process).
+            with contextlib.suppress(Exception):
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            with contextlib.suppress(Exception):
+                await proc.wait()  # bukan communicate() — hindari zombie pipe
+            LOGGER.warning("mediainfo timeout setelah %ss: %s", timeout, " ".join(cmd_args)[:120])
             return "", f"TIMEOUT setelah {timeout}s", -1
     except Exception as err:
         LOGGER.debug("mediainfo gagal: %s", err)
@@ -360,6 +373,12 @@ def _is_mp4_family(file_path: str) -> bool:
         return b"ftyp" in head
     except Exception:
         return False
+
+
+async def _run_mediainfo(file_path: str) -> str | None:
+    """Jalankan mediainfo CLI dengan timeout; return stdout (None jika kosong)."""
+    stdout, _, _ = await _mediainfo_timeout(["mediainfo", file_path])
+    return stdout if stdout else None
 
 
 async def _send_result(ctx: Message, process: Message, out: str, strings, media_type: str = "Unknown"):
@@ -431,10 +450,6 @@ async def mediainfo(client: Client, ctx: Message, strings):
                 return await process.edit(strings("dl_limit_exceeded"), del_in=6)
             c_time = time.time()
             dc_id = FileId.decode(file_info.file_id).dc_id
-
-            async def _run_mediainfo(path):
-                stdout, _, _ = await _mediainfo_timeout(f'mediainfo "{path}"')
-                return stdout if stdout else None
 
             # --- Percobaan 1: partial download (head+tail), tanpa download penuh ---
             file_path = await _partial_download(client, file_info, file_size)
@@ -527,8 +542,7 @@ async def mediainfo(client: Client, ctx: Message, strings):
                 if not file_path:
                     return await process.edit(strings("err_link"), del_in=6)
 
-            stdout, _, _ = await _mediainfo_timeout(f'mediainfo "{file_path}"')
-            out = stdout if stdout else None
+            out = await _run_mediainfo(file_path)
 
             # Partial kurang lengkap & file masih masuk akal -> coba full stream
             if not _looks_complete(out) and total and total <= MAX_URL_FULL:
@@ -538,8 +552,7 @@ async def mediainfo(client: Client, ctx: Message, strings):
                     link, "downloads", f"{job}_full", force_full=True, gid=gid
                 )
                 if file_path:
-                    stdout, _, _ = await _mediainfo_timeout(f'mediainfo "{file_path}"')
-                    out = stdout if stdout else None
+                    out = await _run_mediainfo(file_path)
 
             if not _looks_complete(out):
                 await _cleanup([file_path])

--- a/misskaty/plugins/mediainfo.py
+++ b/misskaty/plugins/mediainfo.py
@@ -27,7 +27,7 @@ from pyrogram.file_id import FileId, FileType
 from pyrogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 from misskaty import app
-from misskaty.helper import post_to_telegraph, runcmd
+from misskaty.helper import post_to_telegraph
 from misskaty.helper.chat_utils import get_file_id
 from misskaty.helper.localization import use_chat_lang
 from misskaty.helper.mediainfo_paste import mediainfo_paste
@@ -292,10 +292,74 @@ async def _download_url_partial(url: str, tmp_dir: str, job: str, force_full: bo
 
 
 def _looks_complete(out: str | None) -> bool:
-    """Heuristik: output mediainfo dianggap lengkap jika ada section utama."""
+    """Heuristik: output mediainfo dianggap lengkap jika ada section utama.
+
+    PENTING: jangan cek "General" — mediainfo pada file parsial (moov
+    rusak/terpotong) tetap return laporan super pendek yang mengandung
+    "General" tapi tanpa section Video/Audio/Text, dan keluar exit 0.
+    Kalau "General" ikut dicek, fallback full download tidak pernah jalan
+    (pelajaran CrossXBot commit 42c2f162).
+    """
     if not out:
         return False
-    return any(section in out for section in ("General", "Video", "Audio"))
+    return any(section in out for section in ("Video", "Audio", "Text"))
+
+
+def _has_moov_atom(file_path: str, scan_mb: int = 20) -> bool:
+    """Cek binary apakah atom ``moov`` ada di 20 MB pertama file.
+
+    MP4/MOV faststart menaruh moov di awal; non-faststart menaruhnya di
+    akhir. Kalau head+tail partial tidak memuat moov -> mediainfo pasti
+    tidak akan bisa baca -> langsung full download lebih hemat daripada
+    buang waktu analisis partial (pelajaran CrossXBot).
+    """
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(scan_mb * 1024 * 1024)
+        return b"moov" in head
+    except Exception:
+        return False
+
+
+async def _mediainfo_timeout(cmd: str, timeout: int = 20) -> tuple[str, str, int]:
+    """Jalankan command dengan timeout; kill process tree kalau hang.
+
+    PENTING: setelah ``proc.kill()`` pakai ``proc.wait()`` BUKAN
+    ``communicate()`` — communicate membaca pipe yang masih dipegang child
+    process yang sudah di-kill -> hang selamanya (zombie). Ini pelajaran
+    CrossXBot commit e461cd0f.
+    """
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout
+            )
+            return (
+                stdout.decode("utf-8", "replace").strip(),
+                stderr.decode("utf-8", "replace").strip(),
+                proc.returncode or 0,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()  # bukan communicate() — hindari zombie pipe
+            LOGGER.warning("mediainfo timeout setelah %ss: %s", timeout, cmd[:120])
+            return "", f"TIMEOUT setelah {timeout}s", -1
+    except Exception as err:
+        LOGGER.debug("mediainfo gagal: %s", err)
+        return "", str(err), -1
+
+
+def _is_mp4_family(file_path: str) -> bool:
+    """True jika file MP4/MOV family (magic ``ftyp`` di header)."""
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(16)
+        return b"ftyp" in head
+    except Exception:
+        return False
 
 
 async def _send_result(ctx: Message, process: Message, out: str, strings, media_type: str = "Unknown"):
@@ -368,9 +432,22 @@ async def mediainfo(client: Client, ctx: Message, strings):
             c_time = time.time()
             dc_id = FileId.decode(file_info.file_id).dc_id
 
+            async def _run_mediainfo(path):
+                stdout, _, _ = await _mediainfo_timeout(f'mediainfo "{path}"')
+                return stdout if stdout else None
+
             # --- Percobaan 1: partial download (head+tail), tanpa download penuh ---
             file_path = await _partial_download(client, file_info, file_size)
             partial_used = file_path is not None
+
+            # MP4/MOV non-faststart (moov di akhir): partial head+tail tidak
+            # memuat moov -> mediainfo pasti gagal. Langsung full download
+            # lebih hemat daripada analisis partial yang buang waktu.
+            if partial_used and _is_mp4_family(file_path) and not _has_moov_atom(file_path):
+                LOGGER.info("MP4 tanpa moov di partial, langsung full download")
+                await _cleanup([file_path])
+                file_path = None
+                partial_used = False
 
             if not partial_used:
                 if file_size > FULL_DL_LIMIT:
@@ -387,8 +464,7 @@ async def mediainfo(client: Client, ctx: Message, strings):
                     return await process.edit("ERROR: FileNotFound.")
                 file_path = path.join("downloads/", path.basename(dl))
 
-            output_ = await runcmd(f'mediainfo "{file_path}"')
-            out = output_[0] if len(output_) != 0 else None
+            out = await _run_mediainfo(file_path)
 
             # --- Hasil partial kurang lengkap -> fallback download penuh ---
             if partial_used and not _looks_complete(out):
@@ -407,8 +483,7 @@ async def mediainfo(client: Client, ctx: Message, strings):
                 except FileNotFoundError:
                     return await process.edit("ERROR: FileNotFound.")
                 file_path = path.join("downloads/", path.basename(dl))
-                output_ = await runcmd(f'mediainfo "{file_path}"')
-                out = output_[0] if len(output_) != 0 else None
+                out = await _run_mediainfo(file_path)
 
             # Output tetap kosong/tidak lengkap -> jangan kirim file kosong
             if not _looks_complete(out):
@@ -441,8 +516,19 @@ async def mediainfo(client: Client, ctx: Message, strings):
             if not file_path:
                 return await process.edit(strings("err_link"), del_in=6)
 
-            output_ = await runcmd(f'mediainfo "{file_path}"')
-            out = output_[0] if len(output_) != 0 else None
+            # MP4/MOV non-faststart: partial head+tail tanpa moov -> langsung
+            # full stream (hemat: tidak analisis partial yang pasti gagal).
+            if _is_mp4_family(file_path) and not _has_moov_atom(file_path) and total and total <= MAX_URL_FULL:
+                LOGGER.info("URL MP4 tanpa moov di partial, langsung full stream")
+                await _cleanup([file_path])
+                file_path, _ = await _download_url_partial(
+                    link, "downloads", f"{job}_full", force_full=True, gid=gid
+                )
+                if not file_path:
+                    return await process.edit(strings("err_link"), del_in=6)
+
+            stdout, _, _ = await _mediainfo_timeout(f'mediainfo "{file_path}"')
+            out = stdout if stdout else None
 
             # Partial kurang lengkap & file masih masuk akal -> coba full stream
             if not _looks_complete(out) and total and total <= MAX_URL_FULL:
@@ -452,8 +538,8 @@ async def mediainfo(client: Client, ctx: Message, strings):
                     link, "downloads", f"{job}_full", force_full=True, gid=gid
                 )
                 if file_path:
-                    output_ = await runcmd(f'mediainfo "{file_path}"')
-                    out = output_[0] if len(output_) != 0 else None
+                    stdout, _, _ = await _mediainfo_timeout(f'mediainfo "{file_path}"')
+                    out = stdout if stdout else None
 
             if not _looks_complete(out):
                 await _cleanup([file_path])


### PR DESCRIPTION
Follow-up dari feedback tes PR #346.

## mediainfo.py — fallback moov sekarang benar (panduan CrossXBot)
- `_looks_complete` **jangan cek "General"** — mediainfo pada file parsial (moov rusak/terpotong) tetap return laporan pendek yang mengandung "General" tapi tanpa Video/Audio/Text, exit 0 → fallback full download tidak pernah jalan. Sekarang cek hanya Video/Audio/Text (pelajaran CrossXBot `42c2f162`)
- `_has_moov_atom()` — cek binary `moov` di 20 MB pertama; MP4/MOV non-faststart (moov di akhir) langsung full download, hemat waktu analisis partial yang pasti gagal
- `_mediainfo_timeout()` — ganti `runcmd` yang pakai `communicate()` tanpa timeout (bisa hang selamanya di file parsial): timeout 20s + `proc.kill()` + `proc.wait()` (bukan communicate — zombie pipe, pelajaran CrossXBot `e461cd0f`)
- `_is_mp4_family()` — deteksi MP4/MOV via magic `ftyp`

## filters.py — error protect_content
- Pyrogram 2.2.24: `reply_sticker`, `reply_animation`, `reply_video`, `reply_audio`, `reply_voice` **TIDAK punya param `protect_content`** (hanya text/photo/document/video_note yang punya) → TypeError saat filter media dipicu. Param dihapus dari method yang tidak support; `captions`/`reply_markup` tetap dipertahankan

## imdb_search.py — tombol Close
- Tombol Close **di baris sendiri di bawah** (tidak berjejer dengan Open IMDB/Trailer)
- Label tombol Close tanpa emoji ❌ teks (icon custom emoji sudah menampilkan ❌ — sebelumnya dobel)
- Semua ID custom emoji sudah disamakan dengan CrossXBot (verified)

## Summary by Sourcery

Improve mediainfo handling for partial MP4/MOV downloads, fix Pyrogram filter reply errors, and adjust IMDB search close button layout and labeling.

Bug Fixes:
- Ensure mediainfo fallback to full download triggers correctly by checking completeness based on Video/Audio/Text sections only.
- Avoid hangs when running mediainfo by enforcing a timeout and killing stalled processes.
- Prevent wasted partial analysis for non-faststart MP4/MOV files by detecting missing moov atoms and falling back to full download or full streaming.
- Fix TypeError crashes in media filters by removing unsupported protect_content parameters from specific Pyrogram reply methods.

Enhancements:
- Optimize mediainfo behavior for MP4/MOV files by detecting file family via header magic and handling moov placement to choose between partial and full downloads or streams.
- Refine IMDB search inline keyboard so the Close button uses a text-only label and always appears on its own row below other action buttons.