### PR TITLE
fix: duplicate reply on /start help_<module> deep link

### DIFF
--- a/misskaty/plugins/start_help.py
+++ b/misskaty/plugins/start_help.py
@@ -114,11 +114,6 @@ async def start(self, ctx, strings):
             if not mod_obj:
                 return await ctx.reply("Unknown help module.")
             text = strings("help_name").format(mod=mod_obj.__MODULE__) + mod_obj.__HELP__
-            await ctx.reply(
-                text,
-                link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
-                effect_id=5104841245755180586,
-            )
             if module == "federation":
                 return await ctx.reply(
                     text=text,


### PR DESCRIPTION
## Bug
`t.me/MissKatyBot?start=help_nightmode` (dan semua `help_<module>`) mengirim **2 pesan** sekaligus:
1. teks help polos (tanpa tombol)
2. teks help + tombol "back"

## Akar masalah
Handler `/start` di `start_help.py` melakukan `ctx.reply()` **dua kali**: satu reply polos di baris 117-121, lalu reply kedua dengan keyboard di baris 122-136. Reply polos itu redundan — tidak pernah dimaksudkan berdampingan dengan reply berkunci.

## Fix
Hapus reply polos. Sekarang hanya ada satu reply per module:
- module biasa → teks + tombol "back"
- federation → teks + `FED_MARKUP` (path tidak berubah)

## Verifikasi
- `py_compile` OK
- diff: 1 file, -5 baris

Catatan: bukan regresi dari PR #349 — bug ini sudah ada sebelumnya (reply ganda sudah tertulis di kode asli).

## Summary by Sourcery

Bug Fixes:
- Eliminate duplicate responses when using /start help_<module> deep links by sending only one formatted help message per module.