### PR TITLE
fix(imdb): format nomination-only awards

### DIFF
--- a/misskaty/helper/imdb_graphql.py
+++ b/misskaty/helper/imdb_graphql.py
@@ -108,6 +108,8 @@ async def get_imdb_details_graphql(title_id: str):
         )
         if not nominations:
             return None
+        if not wins:
+            return f"{nominations} nominasi"
         return f"{wins} kemenangan dari {nominations - wins} nominasi"
 
     def _people(*categories):


### PR DESCRIPTION
Format awards with no wins as total nominations, e.g. 2 nominasi, instead of 0 kemenangan dari 2 nominasi.

Verified with Piranha 3D GraphQL data and py_compile.

## Summary by Sourcery

Bug Fixes:
- Correct award text for cases with nominations but no wins to display only the total nominations.