### PR TITLE
feat(help): rich table module list + ephemeral welcome/eval/shell

### DIFF
--- a/locales/en-US/start_help.json
+++ b/locales/en-US/start_help.json
@@ -7,5 +7,8 @@
     "back_btn": "Back",
     "click_btn": "Click on the below button to get help about {nm}",
     "pm_detail": "PM Me For More Details.",
-    "start_msg": "Hello <emoji id=5303081040464585038>🤗</emoji> {kamuh}, PM me to know about all my features. You can change language bot using /setlang command, but it's still in beta stage."
+    "start_msg": "Hello <emoji id=5303081040464585038>🤗</emoji> {kamuh}, PM me to know about all my features. You can change language bot using /setlang command, but it's still in beta stage.",
+    "help_modules_title": "📚 Available Modules",
+    "help_modules_hint": "Tap a module button above for details, or use {cmd} <module>.",
+    "help_modules_foot": "Powered by {bot}"
 }

--- a/locales/id-ID/start_help.json
+++ b/locales/id-ID/start_help.json
@@ -7,5 +7,8 @@
     "back_btn": "Kembali",
     "click_btn": "Klik tombol di bawah untuk mendapatkan bantuan tentang {nm}",
     "pm_detail": "PM Saya Untuk Detail Lebih Lanjut.",
-    "start_msg": "Halo <emoji id=5303081040464585038>🤗</emoji> {kamuh}, PM saya untuk tahu semua fitur. Kamu bisa mengubah bahasa bot dengan perintah /setlang, tapi masih tahap beta."
+    "start_msg": "Halo <emoji id=5303081040464585038>🤗</emoji> {kamuh}, PM saya untuk tahu semua fitur. Kamu bisa mengubah bahasa bot dengan perintah /setlang, tapi masih tahap beta.",
+    "help_modules_title": "📚 Daftar Modul",
+    "help_modules_hint": "Klik tombol modul di atas untuk detail, atau pakai {cmd} <modul>.",
+    "help_modules_foot": "Ditenagai oleh {bot}"
 }

--- a/misskaty/__init__.py
+++ b/misskaty/__init__.py
@@ -13,6 +13,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from beanie import init_beanie
 from pymongo import MongoClient
 from pyrogram import Client
+from pyrogram import types as pyro_types
 
 from database import get_database
 from misskaty.core.client import MissKatyClient
@@ -127,6 +128,34 @@ app.start()
 BOT_ID = app.me.id
 BOT_NAME = app.me.first_name
 BOT_USERNAME = app.me.username
+
+# Daftarkan /eval & /shell sebagai ephemeral commands (Bot API Ephemeral Messages,
+# scope: semua grup). Saat command ini dipanggil member di grup, command & output
+# hanya terlihat oleh pemanggil + bot. Aman dilewati bila fork pyrogram terpasang
+# belum mendukung fitur ini.
+if hasattr(app, "set_bot_commands") and hasattr(pyro_types, "EphemeralMessageParameters"):
+    try:
+
+        async def _register_ephemeral_commands():
+            await app.set_bot_commands(
+                [
+                    pyro_types.BotCommand(
+                        "eval",
+                        "Eksekusi kode Python (output privat: kamu + bot)",
+                        is_ephemeral=True,
+                    ),
+                    pyro_types.BotCommand(
+                        "shell",
+                        "Eksekusi perintah shell (output privat: kamu + bot)",
+                        is_ephemeral=True,
+                    ),
+                ],
+                scope=pyro_types.BotCommandScopeAllGroupChats(),
+            )
+
+        loop.run_until_complete(_register_ephemeral_commands())
+    except Exception as e:
+        app.log.error(f"Failed to register ephemeral commands: {e}")
 if USER_SESSION:
     try:
         user.start()

--- a/misskaty/helper/misc.py
+++ b/misskaty/helper/misc.py
@@ -92,9 +92,27 @@ def is_module_loaded(name):
 
 
 import asyncio
+import contextlib
 
 
 async def run_sync(func, *args, **kwargs):
     """Run a blocking function in the default executor to avoid stalling the event loop."""
     loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, lambda: func(*args, **kwargs))
+
+
+async def schedule_msg_delete(msg, delay: int):
+    """Hapus `msg` otomatis setelah `delay` detik (fire-and-forget, silent-fail).
+
+    Dipakai untuk membuat pesan ephemeral (welcome, output eval/shell, dsb.)
+    tanpa memblokir handler. Aman dipanggil dengan msg=None.
+    """
+    if msg is None:
+        return
+
+    async def _auto_delete():
+        await asyncio.sleep(delay)
+        with contextlib.suppress(Exception):
+            await msg.delete_msg()
+
+    asyncio.create_task(_auto_delete())

--- a/misskaty/plugins/dev.py
+++ b/misskaty/plugins/dev.py
@@ -96,6 +96,75 @@ async def edit_or_reply(self, msg, **kwargs):
     await func(**{k: v for k, v in kwargs.items() if k in spec})
 
 
+def _eph_params(self: Client, ctx: Message):
+    """EphemeralMessageParameters untuk /eval & /shell yang dipanggil di grup.
+
+    Output command dikirim sebagai ephemeral message sehingga hanya terlihat
+    oleh pemanggil (owner) + bot. Return None di PM (tidak perlu), di userbot,
+    atau bila fork terpasang belum punya tipe ini (degradasi aman ke jalur lama).
+    """
+    if ctx.chat.type == enums.ChatType.PRIVATE:
+        return None
+    if not getattr(self.me, "is_bot", False):
+        return None
+    if not ctx.from_user:
+        return None
+    cls = getattr(pyro_types, "EphemeralMessageParameters", None)
+    if cls is None:
+        return None
+    return cls(receiver_user_id=ctx.from_user.id)
+
+
+async def _send_eph_text(self: Client, ctx: Message, eph, text: str):
+    """Kirim output text. Di grup: ephemeral (privat utk pemanggil + bot);
+    bila Telegram menolak, fallback kirim normal + auto-delete 10 menit."""
+    if eph is not None:
+        try:
+            return await app.send_message(
+                ctx.chat.id,
+                text=text,
+                parse_mode=enums.ParseMode.HTML,
+                ephemeral_message_parameters=eph,
+            )
+        except Exception as e:
+            LOGGER.warning(
+                f"send ephemeral gagal ({e.__class__.__name__}): {e}, fallback normal"
+            )
+    msg = await app.send_message(
+        ctx.chat.id, text=text, parse_mode=enums.ParseMode.HTML
+    )
+    if eph is not None:
+        await schedule_msg_delete(msg, 600)
+    return msg
+
+
+async def _send_eph_doc(
+    self: Client, ctx: Message, eph, doc, caption: str, file_name: str, thumb=None
+):
+    """Kirim output sebagai dokumen (output kepanjangan). Fallback sama
+    seperti _send_eph_text."""
+    if eph is not None:
+        try:
+            return await app.send_document(
+                ctx.chat.id,
+                document=doc,
+                caption=caption,
+                file_name=file_name,
+                thumb=thumb,
+                ephemeral_message_parameters=eph,
+            )
+        except Exception as e:
+            LOGGER.warning(
+                f"send ephemeral doc gagal ({e.__class__.__name__}): {e}, fallback normal"
+            )
+    msg = await app.send_document(
+        ctx.chat.id, document=doc, caption=caption, file_name=file_name, thumb=thumb
+    )
+    if eph is not None:
+        await schedule_msg_delete(msg, 600)
+    return msg
+
+
 @app.on_message(filters.command(["privacy"], COMMAND_HANDLER))
 @use_chat_lang()
 async def privacy_policy(self: Client, ctx: Message, strings):
@@ -460,13 +529,42 @@ async def shell_cmd(self: Client, ctx: Message, strings):
         else await ctx.reply(strings("run_exec"))
     )
     shell = (await shell_exec(ctx.input))[0]
+    eph = _eph_params(self, ctx)
     if len(shell) > 3000:
         with io.BytesIO(str.encode(shell)) as doc:
             doc.name = "shell_output.txt"
-            sent = await ctx.reply_document(
-                document=doc,
-                caption=f"<code>{ctx.input[: 4096 // 4 - 1]}</code>",
-                file_name=doc.name,
+            caption = f"<code>{ctx.input[: 4096 // 4 - 1]}</code>"
+            if eph is not None:
+                await _send_eph_doc(self, ctx, eph, doc, caption, doc.name)
+                await msg.delete_msg()
+            else:
+                sent = await ctx.reply_document(
+                    document=doc,
+                    caption=caption,
+                    file_name=doc.name,
+                    reply_markup=InlineKeyboardMarkup(
+                        [
+                            [
+                                InlineKeyboardButton(
+                                    text=strings("cl_btn"),
+                                    callback_data=f"close#{ctx.from_user.id if ctx.from_user else self.me.id}",
+                                )
+                            ]
+                        ]
+                    ),
+                )
+                await msg.delete_msg()
+                await schedule_msg_delete(sent, 600)
+    elif len(shell) != 0:
+        if eph is not None:
+            await _send_eph_text(self, ctx, eph, html.escape(shell))
+            await msg.delete_msg()
+        else:
+            await edit_or_reply(
+                self,
+                ctx,
+                text=html.escape(shell),
+                parse_mode=enums.ParseMode.HTML,
                 reply_markup=InlineKeyboardMarkup(
                     [
                         [
@@ -478,28 +576,9 @@ async def shell_cmd(self: Client, ctx: Message, strings):
                     ]
                 ),
             )
-            await msg.delete_msg()
-            await schedule_msg_delete(sent, 600)
-    elif len(shell) != 0:
-        await edit_or_reply(
-            self,
-            ctx,
-            text=html.escape(shell),
-            parse_mode=enums.ParseMode.HTML,
-            reply_markup=InlineKeyboardMarkup(
-                [
-                    [
-                        InlineKeyboardButton(
-                            text=strings("cl_btn"),
-                            callback_data=f"close#{ctx.from_user.id if ctx.from_user else self.me.id}",
-                        )
-                    ]
-                ]
-            ),
-        )
-        if self.me.is_bot:
-            await msg.delete_msg()
-            await schedule_msg_delete(ctx, 600)
+            if self.me.is_bot:
+                await msg.delete_msg()
+                await schedule_msg_delete(ctx, 600)
     else:
         await edit_or_reply(self, ctx, text=strings("no_cmd"), del_in=30)
 
@@ -612,14 +691,45 @@ async def cmd_eval(self: Client, ctx: Message, strings) -> Optional[str]:
     if out.endswith("\n"):
         out = out[:-1]
     final_output = f"{prefix}<b>INPUT:</b>\n<pre language='python'>{html.escape(code)}</pre>\n<b>OUTPUT:</b>\n<pre language='python'>{html.escape(out)}</pre>\nExecuted Time: {el_str}"
+    eph = _eph_params(self, ctx)
     if len(final_output) > 4096:
         with io.BytesIO(str.encode(out)) as out_file:
             out_file.name = "MissKatyEval.txt"
-            sent = await ctx.reply_document(
-                document=out_file,
-                caption=f"<code>{code[: 4096 // 4 - 1]}</code>",
-                disable_notification=True,
-                thumb="assets/thumb.jpg",
+            caption = f"<code>{code[: 4096 // 4 - 1]}</code>"
+            if eph is not None:
+                await _send_eph_doc(
+                    self, ctx, eph, out_file, caption, out_file.name, thumb="assets/thumb.jpg"
+                )
+                await status_message.delete_msg()
+            else:
+                sent = await ctx.reply_document(
+                    document=out_file,
+                    caption=caption,
+                    disable_notification=True,
+                    thumb="assets/thumb.jpg",
+                    reply_markup=InlineKeyboardMarkup(
+                        [
+                            [
+                                InlineKeyboardButton(
+                                    text=strings("cl_btn"),
+                                    callback_data=f"close#{ctx.from_user.id if ctx.from_user else self.me.id}",
+                                )
+                            ]
+                        ]
+                    ),
+                )
+                await status_message.delete_msg()
+                await schedule_msg_delete(sent, 600)
+    else:
+        if eph is not None:
+            await _send_eph_text(self, ctx, eph, final_output)
+            await status_message.delete_msg()
+        else:
+            await edit_or_reply(
+                self,
+                ctx,
+                text=final_output,
+                parse_mode=enums.ParseMode.HTML,
                 reply_markup=InlineKeyboardMarkup(
                     [
                         [
@@ -631,28 +741,9 @@ async def cmd_eval(self: Client, ctx: Message, strings) -> Optional[str]:
                     ]
                 ),
             )
-            await status_message.delete_msg()
-            await schedule_msg_delete(sent, 600)
-    else:
-        await edit_or_reply(
-            self,
-            ctx,
-            text=final_output,
-            parse_mode=enums.ParseMode.HTML,
-            reply_markup=InlineKeyboardMarkup(
-                [
-                    [
-                        InlineKeyboardButton(
-                            text=strings("cl_btn"),
-                            callback_data=f"close#{ctx.from_user.id if ctx.from_user else self.me.id}",
-                        )
-                    ]
-                ]
-            ),
-        )
-        if self.me.is_bot:
-            await status_message.delete_msg()
-            await schedule_msg_delete(ctx, 600)
+            if self.me.is_bot:
+                await status_message.delete_msg()
+                await schedule_msg_delete(ctx, 600)
 
 
 # Update and restart bot

--- a/misskaty/plugins/dev.py
+++ b/misskaty/plugins/dev.py
@@ -57,6 +57,7 @@ from misskaty import BOT_NAME, app, botStartTime, misskaty_version, user
 from misskaty.core.decorator import new_task
 from misskaty.helper.eval_helper import format_exception, meval
 from misskaty.helper.functions import extract_user, extract_user_and_reason
+from misskaty.helper.misc import schedule_msg_delete
 from misskaty.helper.http import fetch
 from misskaty.helper.human_read import get_readable_file_size, get_readable_time
 from misskaty.helper.localization import use_chat_lang
@@ -462,7 +463,7 @@ async def shell_cmd(self: Client, ctx: Message, strings):
     if len(shell) > 3000:
         with io.BytesIO(str.encode(shell)) as doc:
             doc.name = "shell_output.txt"
-            await ctx.reply_document(
+            sent = await ctx.reply_document(
                 document=doc,
                 caption=f"<code>{ctx.input[: 4096 // 4 - 1]}</code>",
                 file_name=doc.name,
@@ -478,6 +479,7 @@ async def shell_cmd(self: Client, ctx: Message, strings):
                 ),
             )
             await msg.delete_msg()
+            await schedule_msg_delete(sent, 600)
     elif len(shell) != 0:
         await edit_or_reply(
             self,
@@ -497,8 +499,9 @@ async def shell_cmd(self: Client, ctx: Message, strings):
         )
         if self.me.is_bot:
             await msg.delete_msg()
+            await schedule_msg_delete(ctx, 600)
     else:
-        await ctx.reply(strings("no_reply"), del_in=5)
+        await edit_or_reply(self, ctx, text=strings("no_cmd"), del_in=30)
 
 
 @app.on_message(
@@ -519,7 +522,7 @@ async def shell_cmd(self: Client, ctx: Message, strings):
 @use_chat_lang()
 async def cmd_eval(self: Client, ctx: Message, strings) -> Optional[str]:
     if (ctx.command and len(ctx.command) == 1) or ctx.text == "app.run()":
-        return await edit_or_reply(self, ctx, text=strings("no_eval"))
+        return await edit_or_reply(self, ctx, text=strings("no_eval"), del_in=30)
     status_message = (
         await ctx.edit(strings("run_eval"))
         if not self.me.is_bot
@@ -612,7 +615,7 @@ async def cmd_eval(self: Client, ctx: Message, strings) -> Optional[str]:
     if len(final_output) > 4096:
         with io.BytesIO(str.encode(out)) as out_file:
             out_file.name = "MissKatyEval.txt"
-            await ctx.reply_document(
+            sent = await ctx.reply_document(
                 document=out_file,
                 caption=f"<code>{code[: 4096 // 4 - 1]}</code>",
                 disable_notification=True,
@@ -629,6 +632,7 @@ async def cmd_eval(self: Client, ctx: Message, strings) -> Optional[str]:
                 ),
             )
             await status_message.delete_msg()
+            await schedule_msg_delete(sent, 600)
     else:
         await edit_or_reply(
             self,
@@ -648,6 +652,7 @@ async def cmd_eval(self: Client, ctx: Message, strings) -> Optional[str]:
         )
         if self.me.is_bot:
             await status_message.delete_msg()
+            await schedule_msg_delete(ctx, 600)
 
 
 # Update and restart bot

--- a/misskaty/plugins/grup_tools.py
+++ b/misskaty/plugins/grup_tools.py
@@ -25,11 +25,14 @@ from database.greetings_db import (
 from database.users_chats_db import db
 from misskaty import BOT_USERNAME, app
 from misskaty.core.decorator import asyncify, capture_err
-from misskaty.helper import fetch, use_chat_lang
+from misskaty.helper import fetch, schedule_msg_delete, use_chat_lang
 from misskaty.vars import COMMAND_HANDLER, SUPPORT_CHAT, OWNER_ID
 from misskaty.helper.chat_utils import temp
 
 LOGGER = getLogger("MissKaty")
+
+# Pesan welcome otomatis terhapus (ephemeral) setelah N detik.
+WELCOME_DELETE_DELAY = 300
 
 
 def circle(pfp, size=(215, 215)):
@@ -157,6 +160,9 @@ async def member_has_joined(c: Client, member: ChatMemberUpdated, strings):
                 member.chat.id,
                 photo=welcomeimg,
                 caption=caption,
+            )
+            await schedule_msg_delete(
+                temp.MELCOW[f"welcome-{member.chat.id}"], WELCOME_DELETE_DELAY
             )
         except Exception as e:
             LOGGER.info(e)

--- a/misskaty/plugins/start_help.py
+++ b/misskaty/plugins/start_help.py
@@ -6,6 +6,8 @@
 """
 import contextlib
 import re
+from html import escape
+from logging import getLogger
 
 from pyrogram import Client, filters
 from pyrogram import types as pyro_types
@@ -14,6 +16,7 @@ from pyrogram.types import (
     CallbackQuery,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
+    InputRichMessage,
     Message,
 )
 
@@ -22,6 +25,8 @@ from misskaty import BOT_NAME, BOT_USERNAME, HELPABLE, app
 from misskaty.helper import bot_sys_stats, paginate_modules
 from misskaty.helper.localization import use_chat_lang
 from misskaty.vars import COMMAND_HANDLER
+
+LOGGER = getLogger("MissKaty")
 
 home_keyboard_pm = InlineKeyboardMarkup(
     [
@@ -130,10 +135,11 @@ async def start(self, ctx, strings):
                 effect_id=5104841245755180586,
             )
         elif name == "help":
-            text, keyb = await help_parser(ctx.from_user.first_name, strings)
+            text, keyb, rich_html = await help_parser(ctx.from_user.first_name, strings)
             await ctx.reply(
                 text, reply_markup=keyb, effect_id=5104841245755180586
             )
+            await _send_help_rich(ctx, rich_html)
     else:
         await self.send_photo(
             ctx.chat.id,
@@ -147,13 +153,22 @@ async def start(self, ctx, strings):
 @app.on_callback_query(filters.regex("bot_commands"))
 @use_chat_lang()
 async def commands_callbacc(_, cb: CallbackQuery, strings):
-    text, keyb = await help_parser(cb.from_user.mention, strings)
+    text, keyb, rich_html = await help_parser(cb.from_user.mention, strings)
     await app.send_message(
         cb.message.chat.id,
         text=text,
         reply_markup=keyb,
         effect_id=5104841245755180586,
     )
+    try:
+        await app.send_rich_message(
+            cb.message.chat.id,
+            InputRichMessage(html=rich_html),
+        )
+    except Exception as e:
+        LOGGER.warning(
+            f"help rich message gagal ({e.__class__.__name__}): {e}"
+        )
     await cb.message.delete_msg()
 
 
@@ -184,11 +199,12 @@ async def help_command(_, ctx: Message, strings):
                 await ctx.reply(
                     strings("click_btn").format(nm=name),
                     reply_markup=key,
+                    del_in=120,
                 )
             else:
-                await ctx.reply(strings("pm_detail"), reply_markup=keyboard)
+                await ctx.reply(strings("pm_detail"), reply_markup=keyboard, del_in=120)
         else:
-            await ctx.reply(strings("pm_detail"), reply_markup=keyboard)
+            await ctx.reply(strings("pm_detail"), reply_markup=keyboard, del_in=120)
     elif len(ctx.command) >= 2:
         name = (ctx.text.split(None, 1)[1]).replace(" ", "_").lower()
         if str(name) in HELPABLE:
@@ -202,30 +218,83 @@ async def help_command(_, ctx: Message, strings):
                 effect_id=5104841245755180586,
             )
         else:
-            text, help_keyboard = await help_parser(ctx.from_user.first_name, strings)
+            text, help_keyboard, rich_html = await help_parser(
+                ctx.from_user.first_name, strings
+            )
             await ctx.reply(
                 text,
                 reply_markup=help_keyboard,
                 link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
                 effect_id=5104841245755180586,
             )
+            await _send_help_rich(ctx, rich_html)
     else:
-        text, help_keyboard = await help_parser(ctx.from_user.first_name, strings)
+        text, help_keyboard, rich_html = await help_parser(
+            ctx.from_user.first_name, strings
+        )
         await ctx.reply(
             text,
             reply_markup=help_keyboard,
             link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
             effect_id=5104841245755180586,
         )
+        await _send_help_rich(ctx, rich_html)
+
+
+def _build_help_table(strings) -> str:
+    """Bangun HTML tabel daftar modul help (pola rich message prayer_reminder).
+
+    Modul dibagi 2 kolom kiri/kanan, seimbang sesuai jumlah modul terdaftar.
+    """
+    mods = sorted(x.__MODULE__ for x in HELPABLE.values())
+    half = (len(mods) + 1) // 2
+    left, right = mods[:half], mods[half:]
+    rows = []
+    for i in range(half):
+        left_cell = escape(left[i])
+        right_cell = escape(right[i]) if i < len(right) else ""
+        rows.append(f"<tr><td>• {left_cell}</td><td>• {right_cell}</td></tr>")
+    return (
+        "<table bordered striped>"
+        f"<caption>{escape(strings('help_modules_title'))}</caption>"
+        f"{''.join(rows)}"
+        "</table>"
+    )
+
+
+async def _send_help_rich(ctx: Message, rich_html: str) -> None:
+    """Kirim daftar modul sebagai rich message (tabel rapi).
+
+    help_txt + tombol tetap dikirim sebagai pesan biasa dulu supaya navigasi
+    callback (help_back/prev/next) mengedit pesan plain, bukan rich message;
+    rich table dikirim terpisah TANPA keyboard. Kalau rich gagal (server TG
+    tidak bisa render), fallback aman: pesan biasa + tombol modul tetap ada.
+    """
+    try:
+        await app.send_rich_message(
+            ctx.chat.id,
+            InputRichMessage(html=rich_html),
+            reply_parameters=pyro_types.ReplyParameters(message_id=ctx.id),
+        )
+    except Exception as e:
+        LOGGER.warning(
+            f"help rich message gagal ({e.__class__.__name__}): {e}"
+        )
 
 
 async def help_parser(name, strings, keyb=None):
     if not keyb:
         keyb = InlineKeyboardMarkup(paginate_modules(0, HELPABLE, "help"))
-    return (
-        strings("help_txt").format(kamuh=name, bot=BOT_NAME),
-        keyb,
+    top_text = strings("help_txt").format(kamuh=name, bot=BOT_NAME)
+    rich_html = (
+        f"<p>{top_text}</p>"
+        f"<p>{escape(strings('help_modules_hint').format(cmd='/help'))}</p>"
+        f"{_build_help_table(strings)}"
+        "<aside>"
+        f"{escape(strings('help_modules_foot').format(bot=BOT_NAME))}"
+        "</aside>"
     )
+    return top_text, keyb, rich_html
 
 
 @app.on_callback_query(filters.regex(r"help_(.*?)"))
@@ -294,12 +363,13 @@ async def help_button(self: Client, query: CallbackQuery, strings):
         )
 
     elif create_match:
-        text, keyb = await help_parser(query.from_user.first_name, strings)
+        text, keyb, rich_html = await help_parser(query.from_user.first_name, strings)
         await query.message.edit(
             text=text,
             reply_markup=keyb,
             link_preview_options=pyro_types.LinkPreviewOptions(is_disabled=True),
         )
+        await _send_help_rich(query.message, rich_html)
 
     try:
         await self.answer_callback_query(query.id)


### PR DESCRIPTION
## Ringkasan

- **Help menu**: daftar modul kini juga dikirim sebagai **rich message** berisi tabel 2 kolom (`<table bordered striped>`, pola terbukti dari `prayer_reminder`) — rapi dan auto-fit semua modul. Keyboard navigasi (Back/❮/❯) **tetap di pesan plain** sebagai carrier callback, jadi `help_back/prev/next` tidak pernah menyentuh rich message. Kalau render rich gagal, hanya warning di log — pesan plain + tombol tetap tampil (fallback aman).
- **Welcome**: pesan bergambar selamat datang jadi **ephemeral** — auto-delete 5 menit (300s) via helper baru `schedule_msg_delete()` (fire-and-forget, silent-fail). Guard replace `MELCOW` lama tetap berlaku untuk member yang bergabung beruntun.
- **Eval & Shell**: output inline auto-delete 10 menit; dokumen fallback (>4096 char eval / >3000 char shell) juga auto-delete 10 menit; pesan "tidak ada perintah/eval" pakai `del_in=30`.

## Catatan

- String locale baru `help_modules_title` / `help_modules_hint` / `help_modules_foot` ditambahkan di `en-US` + `id-ID`; locale lain fallback ke `en-US` otomatis.
- Semua call site `help_parser()` (5 titik) sudah di-update ke tuple 3 elemen.

## Testing

- [x] `py_compile` + `pyflakes` bersih untuk 4 file yang diubah
- [x] Simulasi `_build_help_table` dengan 36 modul → 18 baris seimbang 2 kolom
- [x] Verifikasi signature `send_rich_message` Kurigram `dev` (tanpa `link_preview_options`, `reply_parameters` valid)
- [ ] Deploy ke container & cek `/help`, `/eval`, `/shell` + welcome member baru di grup

Signed-off-by: yasirarism <yasirarism@users.noreply.github.com>

## Summary by Sourcery

Improve help presentation and privacy by adding rich module listings and ephemeral handling for welcome, evaluation, and shell messages.

New Features:
- Render the help module list as a separate two-column rich table while retaining plain-message navigation controls.
- Register /eval and /shell as ephemeral group commands when supported by the installed Pyrogram fork.

Enhancements:
- Add reusable silent auto-deletion scheduling for temporary messages.
- Make welcome messages ephemeral and automatically remove eval/shell output and related fallback messages after defined intervals.
- Add localized help table title, hint, and footer strings with English fallback support.

## Ephemeral Commands (update 2)

- `/eval` & `/shell` didaftarkan saat startup sebagai **ephemeral commands** (`BotCommand(is_ephemeral=True)`, scope `BotCommandScopeAllGroupChats`) — fitur Ephemeral Messages Bot API.
- Saat dipanggil **di grup**, output dikirim via `ephemeral_message_parameters` → hanya terlihat oleh **pemanggil (owner) + bot**, pesan "Memproses.." ikut dihapus.
- Di **PM** tetap jalur lama (edit in-place + auto-delete 10 menit).
- Fallback berlapis: fork tanpa `EphemeralMessageParameters` → jalur lama; Telegram menolak ephemeral → kirim normal + auto-delete; startup tidak pernah gagal karena registrasi command.
- Verifikasi signature langsung dari source Kurigram `dev`: `send_message` & `send_document` menerima `ephemeral_message_parameters`, `set_bot_commands` + `BotCommand.is_ephemeral` tersedia.