### PR TITLE
fix(sosmed_tools): tambahkan teks status saat edit cancel markup /download

### DIFF
--- a/misskaty/core/misskaty_patch/bound/message.py
+++ b/misskaty/core/misskaty_patch/bound/message.py
@@ -362,7 +362,11 @@ async def reply(self: Message, text: str, del_in: int = 0, *args, **kwargs):
     return await reply_text(self, text=text, del_in=del_in, *args, **kwargs)
 
 
-async def edit(self: Message, text: str, del_in: int = 0, *args, **kwargs):
+async def edit(self: Message, text: str | None = None, del_in: int = 0, *args, **kwargs):
+    if text is None:
+        if "reply_markup" in kwargs:
+            return await self.edit_reply_markup(kwargs["reply_markup"])
+        return self
     return await edit_text(self, text=text, del_in=del_in, *args, **kwargs)
 
 

--- a/misskaty/plugins/sosmed_tools.py
+++ b/misskaty/plugins/sosmed_tools.py
@@ -121,7 +121,10 @@ async def download(client, message):
         dc_id = FileId.decode(media.file_id).dc_id
         job_id = f"{message.chat.id}:{pesan.id}"
         user_id = message.from_user.id if message.from_user else OWNER_ID
-        await pesan.edit(reply_markup=_tg_download_cancel_markup(job_id, user_id))
+        await pesan.edit(
+            f"<emoji id=5319190934510904031>⏳</emoji> Downloading Telegram file...\nDC ID: {dc_id}",
+            reply_markup=_tg_download_cancel_markup(job_id, user_id),
+        )
         download_task = asyncio.create_task(
             client.download_media(
                 message=message.reply_to_message,


### PR DESCRIPTION
## Masalah

Pada perintah `/download` ketika me-reply media Telegram, terjadi exception:
```
TypeError: edit() missing 1 required positional argument: 'text'
```
Hal ini disebabkan oleh `pesan.edit(reply_markup=...)` yang dipanggil tanpa parameter `text`, sedangkan decorator monkeypatch `Message.edit` di `bound/message.py` mendefinisikan `text: str` sebagai positional argument tanpa default.

## Perbaikan

1. Di `sosmed_tools.py:124`: kirim teks status unduhan (`Downloading Telegram file...\nDC ID: {dc_id}`) bersamaan dengan `reply_markup` cancel.
2. Di `bound/message.py:365`: ubah `edit(self, text: str | None = None, ...)` agar jika `text is None` dan terdapat `reply_markup`, method otomatis mengalirkan ke `edit_reply_markup` tanpa melempar TypeError.

## Summary by Sourcery

Fix Telegram download status updates and make message edits without text safe.

Bug Fixes:
- Prevent Telegram media downloads from failing when updating the cancellation markup without message text.

Enhancements:
- Display the Telegram download status and data-center ID while a file is being downloaded.
- Allow message edits without text to update reply markup or safely leave the message unchanged.